### PR TITLE
Parallel sub-catchments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   area 1.0 reproduces the previous single-cascade behaviour exactly, so
   existing configurations and calls are unchanged. New `SubCatchment` class
   and `Buckets.sub_catchments` / `Buckets.n_sub_catchments`.
+  `run_and_score` chains per-sub-catchment storage state (reservoir depths,
+  snowpack, frozen-ground index, carried deficit) across decade windows:
+  `final_states` / `initial_states` are nested per sub-catchment when there
+  are several, and stay flat/scalar for a single sub-catchment.
 
 ## [3.0.0] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Parallel sub-catchments: a basin can be partitioned into spatially distinct
+  zones that drain to the same channel in parallel, each with its own
+  reservoir cascade and snowpack/frozen-ground state. Basin discharge and
+  storage are the area-weighted means over sub-catchments. Configure with a
+  `sub_catchments:` YAML block (each entry has a `name`, `area_fraction`, its
+  own `reservoirs` block, and optional `initial_conditions`); calibrate by
+  passing a `sub_catchments=[...]` argument to `run_and_score`. Supported on
+  both the pure-Python and Numba JIT time loops. A single sub-catchment of
+  area 1.0 reproduces the previous single-cascade behaviour exactly, so
+  existing configurations and calls are unchanged. New `SubCatchment` class
+  and `Buckets.sub_catchments` / `Buckets.n_sub_catchments`.
+
 ## [3.0.0] - 2026-06-23
 
 Major release. The library was renamed from **hydroRaVENS** to **MNiShed**,

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -43,6 +43,17 @@ Snowpack accumulation and positive-degree-day melt.
    :undoc-members:
    :show-inheritance:
 
+SubCatchment
+------------
+
+A parallel hydraulic compartment of the basin with its own reservoir cascade
+and per-compartment snowpack and frozen-ground state.
+
+.. autoclass:: mnished.SubCatchment
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 run_and_score
 -------------
 

--- a/docs/source/calibration.rst
+++ b/docs/source/calibration.rst
@@ -64,7 +64,9 @@ The fields of ``CalibResult`` are:
      - Modeled FDC at 99 exceedance percentiles (log-space).
    * - ``final_states``
      - dict
-     - Reservoir water depths (mm) at the end of the run.  Pass as
+     - End-of-run storage: reservoir depths (mm), snowpack SWE, frozen-ground
+       index, and carried deficit.  Flat for a single-zone basin; nested under
+       ``'sub_catchments'`` for a partitioned basin.  Pass as
        ``initial_states=`` in the next decade run to chain simulations.
    * - ``buckets``
      - :class:`~mnished.Buckets`
@@ -252,6 +254,34 @@ should be omitted.  For large basins, fit one routing step (N=1–3) with a
 timescale of order (basin_length / wave_speed).  Routing parameters are
 calibration parameters and add to :math:`k` if non-trivial.
 
+Calibrating parallel sub-catchments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When the config partitions the basin into parallel sub-catchments (see
+:ref:`sub-catchments-config`), pass a ``sub_catchments`` argument — one dict per
+sub-catchment, in config order — to override that zone's ``area_fraction`` and
+per-reservoir parameters by position.  The config owns the structure (how many
+sub-catchments and reservoirs); the argument overrides the values each
+evaluation:
+
+.. code-block:: python
+
+    result = run_and_score(
+        'wild_rice.yml',
+        sub_catchments=[
+            {'area_fraction': 0.55, 'recession_coeff': [50, 500]},   # till uplands
+            {'area_fraction': 0.45, 'recession_coeff': [1500]},      # clay lowlands
+        ],
+        melt_factor=4.0,        # snow and ET parameters stay basin-level
+    )
+
+This is mutually exclusive with the flat per-reservoir arguments
+(``recession_coeff``, ``multipath_threshold``, …), which apply only to a
+single-cascade config.  Each overridden value counts as one free parameter for
+the AIC, plus ``n_sub_catchments − 1`` when the area fractions are calibrated.
+Because ``final_states`` carries each zone's storage separately, decade chaining
+(below) works unchanged for a partitioned basin.
+
 Chaining decade runs
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -269,8 +299,11 @@ as the initial state of the next:
         spin_up_cycles=0,   # no spin-up — initial states already equilibrated
     )
 
-The ``final_states`` dict has keys matching ``reservoir_order`` in the driver
-config (e.g. ``{'soil': H_soil, 'intermediate': H_int, 'deep': H_deep}``).
+Treat ``final_states`` as an opaque token to pass straight back as
+``initial_states``: it carries the reservoir depths, snowpack, frozen-ground
+index, and carried deficit at the end of the run.  For a partitioned basin it
+is nested per sub-catchment, so each zone's snowpack and storage chain
+independently.
 
 Calibrating initial storage after spin-up
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -518,6 +518,66 @@ may also be set in the ``general`` block).
        reduced proportionally. Default ``0.0`` (hard threshold). Requires
        ``wp_soil > 0``.
 
+.. _sub-catchments-config:
+
+Parallel Sub-catchments (Optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default a configuration describes a single vertical reservoir cascade for
+the whole basin. A basin can instead be partitioned into **parallel
+sub-catchments** — spatially distinct hydraulic zones (for example till
+uplands versus lake-clay lowlands) that drain to the same channel in parallel
+rather than in a vertical cascade. Each sub-catchment has its own reservoir
+cascade, snowpack, and frozen-ground state; basin discharge is the
+area-weighted mean of the sub-catchments. See
+:ref:`parallel-sub-catchments` in the model description for the concept.
+
+Replace the top-level ``reservoirs`` (and the reservoir part of
+``initial_conditions``) with a ``sub_catchments`` list. Each entry mirrors the
+single-cascade form: a unique ``name``, an ``area_fraction``, its own
+``reservoirs`` block (same keys as above), and an optional
+``initial_conditions`` block for that zone's starting reservoir depths and SWE.
+
+.. code-block:: yaml
+
+    sub_catchments:
+      - name: till_uplands
+        area_fraction: 0.55
+        reservoirs:
+          recession_coefficients:        [50, 500]   # a two-reservoir cascade
+          exfiltration_fractions:        [0.6, 1.0]
+          maximum_effective_depths__mm:  [.inf, .inf]
+          multipath_thresholds__mm:      [100.0, null]
+          multipath_timescales__days:    [10.0, null]
+        initial_conditions:                            # optional; defaults to 0
+          water_reservoir_effective_depths__mm: [5, 300]
+          snowpack__mm_SWE: 0
+      - name: clay_lowlands
+        area_fraction: 0.45
+        reservoirs:
+          recession_coefficients:        [1500]       # a single reservoir
+          exfiltration_fractions:        [1.0]
+          maximum_effective_depths__mm:  [.inf]
+
+Rules:
+
+* ``area_fraction`` values must sum to 1 (within ``1e-6``).
+* ``name`` is required and must be unique.
+* Each sub-catchment must have at least one reservoir.
+* The number of reservoirs may differ between sub-catchments.
+* A ``forcing`` block per sub-catchment is reserved for a future release (for
+  zone-specific precipitation/ET/temperature) and currently raises
+  ``NotImplementedError``; forcing is shared across sub-catchments for now.
+
+The legacy single ``reservoirs`` block is equivalent to one sub-catchment with
+``area_fraction: 1.0`` and reproduces the original behaviour exactly, so
+existing configurations need no changes.
+
+To calibrate a partitioned basin, pass a ``sub_catchments`` argument to
+:func:`~mnished.calibration.run_and_score` (one dict per sub-catchment, in
+config order) to override ``area_fraction`` and the per-reservoir parameters by
+position; snow and ET parameters remain basin-level.
+
 Complete Example
 ~~~~~~~~~~~~~~~~
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -22,8 +22,9 @@ Configuration File Structure
         # Simulation settings
     
     reservoirs:
-        # Reservoir cascade configuration
-    
+        # Reservoir cascade for the whole basin (a single hydraulic zone).
+        # Replace with `sub_catchments:` to model parallel zones.
+
     snowmelt:
         # Required section; snowpack processes are only active if
         # Mean Temperature [C] is present in the input CSV
@@ -75,6 +76,10 @@ Example:
             - 150    # Top (soil) reservoir starts at 150 mm
             - 400    # Bottom (groundwater) starts at 400 mm
         snowpack__mm_SWE: 50  # 50 mm SWE initially
+
+This top-level block applies to a single-zone basin. When the basin is split
+into parallel zones, each sub-catchment carries its own ``initial_conditions``
+block instead (see :ref:`sub-catchments-config`).
 
 The ``catchment`` section
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -197,9 +202,10 @@ Example:
 The ``reservoirs`` section
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This section defines the cascade of reservoirs (1 or more); each may be
-linear or nonlinear (power-law, via ``recession_exponents``).
-All lists must have the same length.
+This section defines the cascade of reservoirs (1 or more) for a basin treated
+as a single hydraulic zone; each may be linear or nonlinear (power-law, via
+``recession_exponents``). All lists must have the same length. To split the
+basin into parallel zones, use :ref:`sub-catchments-config` instead.
 
 .. list-table::
    :widths: 35 15 40
@@ -313,6 +319,65 @@ No reservoir is fixed to a particular process; physical meaning is set
 by the parameters. Successive reservoirs naturally span progressively
 longer storage timescales — from interflow (days) to soil moisture
 (months) to groundwater (years) — but that mapping is the user's choice.
+
+A single ``reservoirs`` block describes one cascade for the whole basin. To
+split the basin into parallel hydraulic zones, use the ``sub_catchments``
+section below instead.
+
+.. _sub-catchments-config:
+
+The ``sub_catchments`` section
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``sub_catchments`` in place of the top-level ``reservoirs`` block to
+represent a basin as several **parallel sub-catchments** — spatially distinct
+hydraulic zones (for example till uplands versus lake-clay lowlands) that drain
+to the same channel in parallel rather than through one vertical cascade. Each
+entry is one zone and mirrors the single-cascade form: a unique ``name``, an
+``area_fraction``, its own ``reservoirs`` block (same keys as above), and an
+optional ``initial_conditions`` block for that zone's starting reservoir depths
+and SWE. Basin discharge is the area-weighted mean of the sub-catchments; see
+:ref:`parallel-sub-catchments` for the concept.
+
+.. code-block:: yaml
+
+    sub_catchments:
+      - name: till_uplands
+        area_fraction: 0.55
+        reservoirs:
+          recession_coefficients:        [50, 500]   # a two-reservoir cascade
+          exfiltration_fractions:        [0.6, 1.0]
+          maximum_effective_depths__mm:  [.inf, .inf]
+          multipath_thresholds__mm:      [100.0, null]
+          multipath_timescales__days:    [10.0, null]
+        initial_conditions:                            # optional; defaults to 0
+          water_reservoir_effective_depths__mm: [5, 300]
+          snowpack__mm_SWE: 0
+      - name: clay_lowlands
+        area_fraction: 0.45
+        reservoirs:
+          recession_coefficients:        [1500]       # a single reservoir
+          exfiltration_fractions:        [1.0]
+          maximum_effective_depths__mm:  [.inf]
+
+Rules:
+
+* ``area_fraction`` values must sum to 1 (within ``1e-6``).
+* ``name`` is required and must be unique.
+* Each sub-catchment must have at least one reservoir.
+* The number of reservoirs may differ between sub-catchments.
+* A ``forcing`` block per sub-catchment is reserved for a future release (for
+  zone-specific precipitation/ET/temperature) and currently raises
+  ``NotImplementedError``; forcing is shared across sub-catchments for now.
+
+A single ``reservoirs`` block is exactly equivalent to one ``sub_catchments``
+entry with ``area_fraction: 1.0``, so the two forms are interchangeable for a
+one-zone basin and existing configurations need no changes.
+
+To calibrate a partitioned basin, pass a ``sub_catchments`` argument to
+:func:`~mnished.calibration.run_and_score` (one dict per sub-catchment, in
+config order) to override ``area_fraction`` and the per-reservoir parameters by
+position; snow and ET parameters remain basin-level.
 
 The ``snowmelt`` section
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -517,66 +582,6 @@ may also be set in the ``general`` block).
        with standard deviation ``wp_soil_sigma``, and ET extraction is
        reduced proportionally. Default ``0.0`` (hard threshold). Requires
        ``wp_soil > 0``.
-
-.. _sub-catchments-config:
-
-Parallel Sub-catchments (Optional)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By default a configuration describes a single vertical reservoir cascade for
-the whole basin. A basin can instead be partitioned into **parallel
-sub-catchments** — spatially distinct hydraulic zones (for example till
-uplands versus lake-clay lowlands) that drain to the same channel in parallel
-rather than in a vertical cascade. Each sub-catchment has its own reservoir
-cascade, snowpack, and frozen-ground state; basin discharge is the
-area-weighted mean of the sub-catchments. See
-:ref:`parallel-sub-catchments` in the model description for the concept.
-
-Replace the top-level ``reservoirs`` (and the reservoir part of
-``initial_conditions``) with a ``sub_catchments`` list. Each entry mirrors the
-single-cascade form: a unique ``name``, an ``area_fraction``, its own
-``reservoirs`` block (same keys as above), and an optional
-``initial_conditions`` block for that zone's starting reservoir depths and SWE.
-
-.. code-block:: yaml
-
-    sub_catchments:
-      - name: till_uplands
-        area_fraction: 0.55
-        reservoirs:
-          recession_coefficients:        [50, 500]   # a two-reservoir cascade
-          exfiltration_fractions:        [0.6, 1.0]
-          maximum_effective_depths__mm:  [.inf, .inf]
-          multipath_thresholds__mm:      [100.0, null]
-          multipath_timescales__days:    [10.0, null]
-        initial_conditions:                            # optional; defaults to 0
-          water_reservoir_effective_depths__mm: [5, 300]
-          snowpack__mm_SWE: 0
-      - name: clay_lowlands
-        area_fraction: 0.45
-        reservoirs:
-          recession_coefficients:        [1500]       # a single reservoir
-          exfiltration_fractions:        [1.0]
-          maximum_effective_depths__mm:  [.inf]
-
-Rules:
-
-* ``area_fraction`` values must sum to 1 (within ``1e-6``).
-* ``name`` is required and must be unique.
-* Each sub-catchment must have at least one reservoir.
-* The number of reservoirs may differ between sub-catchments.
-* A ``forcing`` block per sub-catchment is reserved for a future release (for
-  zone-specific precipitation/ET/temperature) and currently raises
-  ``NotImplementedError``; forcing is shared across sub-catchments for now.
-
-The legacy single ``reservoirs`` block is equivalent to one sub-catchment with
-``area_fraction: 1.0`` and reproduces the original behaviour exactly, so
-existing configurations need no changes.
-
-To calibrate a partitioned basin, pass a ``sub_catchments`` argument to
-:func:`~mnished.calibration.run_and_score` (one dict per sub-catchment, in
-config order) to override ``area_fraction`` and the per-reservoir parameters by
-position; snow and ET parameters remain basin-level.
 
 Complete Example
 ~~~~~~~~~~~~~~~~

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,8 @@ A simple, flexible reservoir-based hydrological model for water balance simulati
 
 **MNiShed** (*MN* = Minnesota, *Mni* = water in Dakota, *Mini* = small/lumped,
 *Shed* = watershed) is a lumped conceptual model that routes precipitation
-through an optional snowpack and a cascade of reservoirs to produce streamflow.
+through an optional snowpack and one or more parallel sub-catchments — each a
+cascade of reservoirs — to produce streamflow.
 Ideal for long water-balance studies, climate impact assessments, and ungauged basins.
 
 **Key Features**
@@ -17,6 +18,9 @@ Ideal for long water-balance studies, climate impact assessments, and ungauged b
 
 * Cascading reservoirs -- linear or nonlinear (power-law) recession, soil to
   groundwater, with optional leakance/threshold junctions and tile drainage
+* Parallel sub-catchments -- partition a basin into spatially distinct
+  hydraulic zones (e.g. till uplands vs. lake-clay lowlands), each its own
+  reservoir cascade, area-weighted to the outlet
 * Calibration -- KGE, NSE, and log-KGE scoring; AIC model comparison; baseflow
   index; flow duration curve; Nash-cascade routing; decadal chaining
 * Fast -- Numba JIT-compiled daily time loop, roughly 100--400× faster than

--- a/docs/source/model_description.rst
+++ b/docs/source/model_description.rst
@@ -346,6 +346,38 @@ where:
   groundwater (years) — but that mapping is the user's choice, analogous
   to the multi-component runoff structure of HBV (Bergström 1976).
 
+.. _parallel-sub-catchments:
+
+Parallel Sub-catchments (Optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The cascade above is *vertical*: water drained from one reservoir recharges
+the one beneath it. Some basins, however, comprise spatially distinct
+hydraulic zones that drain to the same channel **in parallel** rather than in
+a vertical stack — for example till uplands with tile drainage alongside
+lake-clay lowlands, each with its own recession behaviour. Routing these
+through a single vertical cascade conflates a parallel structure into a serial
+one and can only partially represent it.
+
+A basin may instead be partitioned into :math:`K` **parallel sub-catchments**.
+Each sub-catchment :math:`k` is internally an ordinary vertical cascade (with
+its own recession, junction, multipath, and tile parameters) and carries its
+own snowpack and frozen-ground state. Each has a basin-area fraction
+:math:`a_k`, with :math:`\sum_k a_k = 1`. Sub-catchments are advanced
+independently and produce per-unit-area discharge :math:`Q_k`; basin discharge
+is their area-weighted mean:
+
+.. math::
+
+    Q_{\text{basin}} = \sum_{k=1}^{K} a_k \, Q_k
+
+Storage is likewise area-weighted (:math:`\sum_k a_k H_k`), so the basin water
+balance is exact. A single sub-catchment with :math:`a = 1` recovers the plain
+cascade exactly, and existing single-cascade configurations are treated as
+exactly that. In this release all sub-catchments share the basin-level forcing
+(precipitation, ET, temperature); per-sub-catchment forcing is a planned
+extension. See :ref:`sub-catchments-config` for how to configure them.
+
 .. _reservoir-junctions:
 
 Junctions Between Reservoirs (Optional)

--- a/docs/source/model_description.rst
+++ b/docs/source/model_description.rst
@@ -4,9 +4,16 @@ Model Description
 Theory & Mathematical Formulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-MNiShed is a lumped, daily-timestep conceptual hydrological model. Water 
-moves through three sequential processes each day: optional snowpack accumulation/melt,
-routing through cascading reservoirs (linear or nonlinear power-law), and evapotranspiration.
+MNiShed is a lumped, daily-timestep conceptual hydrological model. A basin is
+represented as one or more **parallel sub-catchments** — spatially distinct
+hydraulic zones that drain to the same channel — each routing water through its
+own cascade of reservoirs. The common case is a single sub-catchment spanning
+the whole basin; several sub-catchments resolve zones with genuinely different
+storage–discharge behaviour. Within each sub-catchment, water moves through
+three sequential processes each day: optional snowpack accumulation/melt,
+routing through cascading reservoirs (linear or nonlinear power-law), and
+evapotranspiration. Basin streamflow is the area-weighted mean of the
+sub-catchments.
 
 All fluxes are expressed as depths over the drainage basin (mm/day).
 Mass is conserved to within numerical precision.
@@ -27,6 +34,49 @@ where:
 * :math:`E` = evapotranspiration (mm/day)
 * :math:`\Delta S` = change in storage (mm/day)
 * :math:`Q` = streamflow (mm/day)
+
+For a partitioned basin this balance holds within each sub-catchment; the basin
+totals :math:`Q` and :math:`\Delta S` are the area-weighted sums over
+sub-catchments (see :ref:`parallel-sub-catchments`).
+
+.. _parallel-sub-catchments:
+
+Spatial Structure: Sub-catchments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A basin is partitioned into :math:`K` **parallel sub-catchments** — spatially
+distinct hydraulic zones that drain to the same channel in parallel rather than
+in a vertical stack. The default is a single sub-catchment (:math:`K = 1`)
+spanning the whole basin, which is exactly the reservoir cascade described
+below. Several sub-catchments are used when a basin contains zones with
+genuinely different storage–discharge behaviour — for example till uplands with
+tile drainage alongside lake-clay lowlands — where a single cascade would
+conflate a parallel structure into a serial one and could only partially
+represent it.
+
+Each sub-catchment :math:`k` is internally an ordinary vertical reservoir
+cascade, with its own recession, junction, multipath, and tile-drain
+parameters, and carries its own snowpack, frozen-ground, and carried-deficit
+state. It occupies a basin-area fraction :math:`a_k`, with
+:math:`\sum_{k=1}^{K} a_k = 1`. Sub-catchments are advanced independently each
+day and produce per-unit-area discharge :math:`Q_k`; basin streamflow is their
+area-weighted mean:
+
+.. math::
+
+    Q_{\text{basin}} = \sum_{k=1}^{K} a_k \, Q_k
+
+Storage is area-weighted the same way (:math:`\sum_k a_k H_k`), so the basin
+water balance is exact for any number of sub-catchments. With :math:`K = 1` and
+:math:`a = 1` every aggregation is the identity, recovering the single-cascade
+model exactly; existing single-cascade configurations are treated as precisely
+that and need no changes.
+
+All sub-catchments currently share the basin-level forcing (precipitation, ET,
+temperature); per-sub-catchment forcing is a planned extension. The process
+descriptions that follow are written for a single sub-catchment — when a basin
+defines only one, "the sub-catchment" and "the basin" coincide. See
+:ref:`sub-catchments-config` to configure a partitioned basin.
 
 Optional Process Modules
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -300,8 +350,9 @@ intended physical interpretation.
 Linear Reservoir Cascade
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Water drains through a stack of reservoirs (top = shallowest, bottom = deepest).
-Each reservoir first receives its recharge input, then drains by exponential decay:
+Within a sub-catchment, water drains through a stack of reservoirs (top =
+shallowest, bottom = deepest). Each reservoir first receives its recharge
+input, then drains by exponential decay:
 
 .. math::
 
@@ -345,38 +396,6 @@ where:
   longer timescales — interflow (days), soil moisture (months),
   groundwater (years) — but that mapping is the user's choice, analogous
   to the multi-component runoff structure of HBV (Bergström 1976).
-
-.. _parallel-sub-catchments:
-
-Parallel Sub-catchments (Optional)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The cascade above is *vertical*: water drained from one reservoir recharges
-the one beneath it. Some basins, however, comprise spatially distinct
-hydraulic zones that drain to the same channel **in parallel** rather than in
-a vertical stack — for example till uplands with tile drainage alongside
-lake-clay lowlands, each with its own recession behaviour. Routing these
-through a single vertical cascade conflates a parallel structure into a serial
-one and can only partially represent it.
-
-A basin may instead be partitioned into :math:`K` **parallel sub-catchments**.
-Each sub-catchment :math:`k` is internally an ordinary vertical cascade (with
-its own recession, junction, multipath, and tile parameters) and carries its
-own snowpack and frozen-ground state. Each has a basin-area fraction
-:math:`a_k`, with :math:`\sum_k a_k = 1`. Sub-catchments are advanced
-independently and produce per-unit-area discharge :math:`Q_k`; basin discharge
-is their area-weighted mean:
-
-.. math::
-
-    Q_{\text{basin}} = \sum_{k=1}^{K} a_k \, Q_k
-
-Storage is likewise area-weighted (:math:`\sum_k a_k H_k`), so the basin water
-balance is exact. A single sub-catchment with :math:`a = 1` recovers the plain
-cascade exactly, and existing single-cascade configurations are treated as
-exactly that. In this release all sub-catchments share the basin-level forcing
-(precipitation, ET, temperature); per-sub-catchment forcing is a planned
-extension. See :ref:`sub-catchments-config` for how to configure them.
 
 .. _reservoir-junctions:
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -58,6 +58,10 @@ is a recommended starting point for temperate catchments.  See
 :doc:`configuration` for all available options and :doc:`calibration` for
 guidance on choosing a model structure.
 
+This single cascade treats the basin as one hydraulic zone.  A basin with
+spatially distinct zones (for example till uplands and lake-clay lowlands) can
+instead be split into parallel sub-catchments; see :ref:`sub-catchments-config`.
+
 .. code-block:: yaml
 
     timeseries:

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -317,6 +317,10 @@ because the optimizer can trade τ against *b* while holding MRT nearly
 constant.  See :ref:`Mean Residence Time <mean-residence-time>` in
 :doc:`model_description` for the derivation and interpretation.
 
+This tutorial builds a single-cascade model — one hydraulic zone. A basin with
+spatially distinct zones can be split into parallel sub-catchments, each its own
+cascade; see :ref:`sub-catchments-config` and :ref:`parallel-sub-catchments`.
+
 See Also
 --------
 

--- a/mnished/__init__.py
+++ b/mnished/__init__.py
@@ -1,13 +1,14 @@
 from ._version import __version__
 from .calibration import CalibResult, run_and_score
 from .hydrograph_separation import HydrographSeparation
-from .mnished import Buckets, Reservoir, Snowpack
+from .mnished import Buckets, Reservoir, Snowpack, SubCatchment
 from .priors import Priors, suggest_priors
 from .recession import BrutsaertNieber
 
 __all__ = [
     "Reservoir",
     "Snowpack",
+    "SubCatchment",
     "Buckets",
     "CalibResult",
     "run_and_score",

--- a/mnished/calibration.py
+++ b/mnished/calibration.py
@@ -356,6 +356,121 @@ def _steady_state_depths(reservoirs, mean_q):
     return depths
 
 
+def _apply_reservoir_overrides(reservoirs, over):
+    """
+    Apply per-reservoir parameter overrides from a dict to one cascade.
+
+    Used for per-sub-catchment overrides in run_and_score; mirrors the flat
+    per-reservoir argument semantics but reads from a dict and auto-counts free
+    parameters (the flat path uses explicit ``*_calibrated`` counts instead).
+
+    Parameters
+    ----------
+    reservoirs : list of Reservoir
+        The cascade to mutate, shallowest first.
+    over : dict
+        Override values keyed by parameter name (``'recession_coeff'``,
+        ``'f_to_discharge'``, ``'Hmax'``, ``'multipath_threshold'``,
+        ``'multipath_timescale'``, ``'leakance_R'``, ``'H_threshold'``,
+        ``'recession_exponents'``, ``'f_tile'``, ``'tau_tile'``, ``'pdm_H0'``).
+
+    Returns
+    -------
+    int
+        Number of free parameters set, for AIC k-counting.
+    """
+    k = 0
+
+    rc = over.get('recession_coeff')
+    if rc is not None:
+        for i, val in enumerate(rc):
+            reservoirs[i].recession_coeff = val
+        k += len(rc)
+
+    fd = over.get('f_to_discharge')
+    if fd is not None:
+        for i, val in enumerate(fd):
+            if val is not None:
+                reservoirs[i].f_to_discharge = val
+        k += sum(1 for v in fd if v is not None)
+
+    lk = over.get('leakance_R')
+    if lk is not None:
+        for i, val in enumerate(lk):
+            if val is not None:
+                reservoirs[i].leakance_R = val
+                reservoirs[i].junction_type = 'leakance'
+        k += sum(1 for v in lk if v is not None)
+
+    ht = over.get('H_threshold')
+    if ht is not None:
+        for i, val in enumerate(ht):
+            if val is not None:
+                reservoirs[i].H_threshold = val
+                reservoirs[i].junction_type = 'threshold'
+        k += sum(1 for v in ht if v is not None)
+
+    mthr = over.get('multipath_threshold')
+    mtau = over.get('multipath_timescale')
+    if mthr is not None or mtau is not None:
+        if mthr is None or mtau is None:
+            raise ValueError(
+                "multipath_threshold and multipath_timescale must be "
+                "provided together (or both omitted).")
+        if len(mthr) != len(mtau):
+            raise ValueError(
+                "multipath_threshold and multipath_timescale must have "
+                "the same length.")
+        for i, (thr, tau) in enumerate(zip(mthr, mtau)):
+            if i >= len(reservoirs):
+                break
+            if (thr is None) ^ (tau is None):
+                raise ValueError(
+                    f"Reservoir {i}: multipath_threshold and "
+                    "multipath_timescale must be both None or both set.")
+            reservoirs[i].multipath_threshold = thr
+            reservoirs[i].multipath_timescale = tau
+        k += sum(1 for v in mthr if v is not None)
+
+    hm = over.get('Hmax')
+    if hm is not None:
+        for i, val in enumerate(hm):
+            reservoirs[i].Hmax = val
+        k += sum(1 for v in hm if np.isfinite(v))
+
+    pd_h0 = over.get('pdm_H0')
+    if pd_h0 is not None:
+        for i, val in enumerate(pd_h0):
+            if val is not None:
+                reservoirs[i].pdm_H0 = val
+        k += sum(1 for v in pd_h0 if v is not None)
+
+    ft = over.get('f_tile')
+    tt = over.get('tau_tile')
+    if ft is not None:
+        any_tile = False
+        for i, ftv in enumerate(ft[:len(reservoirs)]):
+            reservoirs[i].f_tile = ftv
+            if ftv > 0.0 and tt is not None:
+                reservoirs[i].tile_res = Reservoir(tt, f_to_discharge=1.0)
+                any_tile = True
+            else:
+                reservoirs[i].tile_res = None
+        k += len({v for v in ft if v > 0.0})
+        if any_tile:
+            k += 1
+
+    re = over.get('recession_exponents')
+    if re is not None:
+        for i, b_exp in enumerate(re):
+            if i >= len(reservoirs):
+                break
+            reservoirs[i].recession_exponent = float(b_exp)
+        k += len(re)
+
+    return k
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -372,6 +487,7 @@ def run_and_score(cfg, recession_coeff=None, f_to_discharge=None, Hmax=None,
                   recession_exponents=None, recession_exponents_calibrated=0,
                   direct_runoff_fraction=None, baseflow_Q=None,
                   modules=None,
+                  sub_catchments=None,
                   initial_states=None,
                   post_spinup_states=None, post_spinup_k=0,
                   start=None, end=None, spin_up_cycles=None,
@@ -530,6 +646,23 @@ def run_and_score(cfg, recession_coeff=None, f_to_discharge=None, Hmax=None,
         ``'frozen_ground'``, ``'rain_on_snow'``, ``'direct_runoff'``.
         Values: bool.  Overrides the ``modules`` block in the YAML config.
         Absent keys leave the YAML/default value unchanged.
+    sub_catchments : list of dict or None, optional
+        Per-sub-catchment parameter overrides for a basin partitioned into
+        parallel sub-catchments (see :class:`mnished.SubCatchment`). The YAML
+        config defines the *structure* (how many sub-catchments and reservoirs);
+        this argument overrides values by position, one dict per sub-catchment
+        in config order. Each dict may contain ``'area_fraction'`` and any of
+        the per-reservoir override lists (``'recession_coeff'``,
+        ``'f_to_discharge'``, ``'Hmax'``, ``'multipath_threshold'``,
+        ``'multipath_timescale'``, ``'leakance_R'``, ``'H_threshold'``,
+        ``'recession_exponents'``, ``'f_tile'``, ``'tau_tile'``, ``'pdm_H0'``),
+        scoped to that sub-catchment's cascade with the same semantics as the
+        flat arguments. Mutually exclusive with the flat per-reservoir
+        arguments. When ``'area_fraction'`` is given it must still sum to 1
+        across sub-catchments. For AIC, every overridden value counts as one
+        free parameter, plus n_sub_catchments - 1 when area fractions are set.
+        Snow and ET parameters remain basin-level (the flat ``melt_factor``,
+        ``et_scale``, etc.). Default None (single-cascade calibration).
     enforce_water_balance : str, optional
         'water-year' (default): scale ET by a per-water-year multiplier so
         that P - Q - ET = 0 over each water year.
@@ -597,6 +730,43 @@ def run_and_score(cfg, recession_coeff=None, f_to_discharge=None, Hmax=None,
 
     # --- Parameter overrides and free-parameter count ---
     k = 0
+
+    if sub_catchments is not None:
+        # Per-sub-catchment overrides. The flat per-reservoir arguments are
+        # mutually exclusive with this; basin-level (snow/ET/routing) overrides
+        # below still apply. The cfg owns the structure (number of
+        # sub-catchments and reservoirs); this overrides values by position.
+        _flat = {
+            'recession_coeff': recession_coeff, 'f_to_discharge': f_to_discharge,
+            'Hmax': Hmax, 'pdm_H0': pdm_H0, 'f_tile': f_tile, 'tau_tile': tau_tile,
+            'multipath_threshold': multipath_threshold,
+            'multipath_timescale': multipath_timescale,
+            'leakance_R': leakance_R, 'H_threshold': H_threshold,
+            'recession_exponents': recession_exponents,
+        }
+        _bad = [name for name, val in _flat.items() if val is not None]
+        if _bad:
+            raise ValueError(
+                "When 'sub_catchments' is given, per-reservoir parameters must "
+                "be supplied inside each sub-catchment dict, not as flat "
+                f"arguments; remove: {_bad}.")
+        if len(sub_catchments) != b.n_sub_catchments:
+            raise ValueError(
+                f"'sub_catchments' has {len(sub_catchments)} entries but the "
+                f"config defines {b.n_sub_catchments} sub-catchments.")
+        _set_area = False
+        for _sc_obj, _sc_over in zip(b.sub_catchments, sub_catchments):
+            if 'area_fraction' in _sc_over:
+                _sc_obj.area_fraction = _sc_over['area_fraction']
+                _set_area = True
+            k += _apply_reservoir_overrides(_sc_obj.reservoirs, _sc_over)
+        if _set_area:
+            _asum = sum(s.area_fraction for s in b.sub_catchments)
+            if abs(_asum - 1.0) > 1e-6:
+                raise ValueError(
+                    f"Sub-catchment area_fraction values must sum to 1.0; "
+                    f"got {_asum:.6f}.")
+            k += b.n_sub_catchments - 1   # last fraction is determined
 
     if recession_coeff is not None:
         for i, val in enumerate(recession_coeff):

--- a/mnished/calibration.py
+++ b/mnished/calibration.py
@@ -112,12 +112,23 @@ fdc_obs : pd.Series
 fdc_mod : pd.Series
     Modelled flow duration curve (same format as fdc_obs).
 final_states : dict
-    End-of-run reservoir states suitable for passing as
-    ``initial_states`` to the next call::
+    End-of-run storage states suitable for passing as ``initial_states`` to
+    the next call. For a single sub-catchment, flat and scalar::
 
         {'reservoirs': [H_shallow, H_deep, ...],  # [mm]
          'snowpack':    H_snow_SWE,               # [mm SWE]
-         'fgi':         frozen_ground_index}       # [°C·day]
+         'fgi':         frozen_ground_index,      # [°C·day]
+         'H_deficit_carry': carried_deficit}      # [mm]
+
+    For several parallel sub-catchments, nested one level deeper — a
+    ``'sub_catchments'`` list with one such dict per sub-catchment (config
+    order), each carrying that zone's reservoir depths, snowpack, FGI, and
+    carried deficit::
+
+        {'sub_catchments': [
+            {'reservoirs': [...], 'snowpack': ..., 'fgi': ...,
+             'H_deficit_carry': ...},  # sub-catchment 0
+            ...]}
 
 buckets : Buckets
     The :class:`~mnished.Buckets` object after the final run,
@@ -471,6 +482,86 @@ def _apply_reservoir_overrides(reservoirs, over):
     return k
 
 
+def _capture_states(b):
+    """
+    Capture end-of-run storage state for chaining to a following run.
+
+    For a single sub-catchment the state is flat and scalar
+    (``{'reservoirs': [...], 'snowpack': float, 'fgi': float,
+    'H_deficit_carry': float}``), identical to earlier versions. For several
+    sub-catchments it is nested one level deeper — a ``'sub_catchments'`` list
+    with one such dict per sub-catchment (in config order), each carrying that
+    zone's reservoir depths plus its own snowpack, FGI, and carried deficit.
+    """
+    def _one(sc):
+        return {
+            'reservoirs':      [r.Hwater for r in sc.reservoirs],
+            'snowpack':        (sc.snowpack.Hwater
+                                if (b.has_snowpack and sc.snowpack is not None)
+                                else 0.0),
+            'fgi':             sc.fgi,
+            'H_deficit_carry': sc.H_deficit_carry,
+        }
+
+    if b.n_sub_catchments == 1:
+        return _one(b.sub_catchments[0])
+    return {'sub_catchments': [_one(sc) for sc in b.sub_catchments]}
+
+
+def _restore_initial_states(b, states):
+    """
+    Restore full initial storage state from a (possibly nested) state dict.
+
+    Accepts either the flat single-sub-catchment form or the nested
+    ``{'sub_catchments': [...]}`` form produced by :func:`_capture_states`;
+    missing snowpack/FGI/deficit entries default to zero (a full restore).
+    """
+    if 'sub_catchments' in states:
+        for sc, s in zip(b.sub_catchments, states['sub_catchments']):
+            for r, h in zip(sc.reservoirs, s['reservoirs']):
+                r.Hwater = h
+            if b.has_snowpack and sc.snowpack is not None:
+                sc.snowpack.Hwater = s.get('snowpack', 0.0)
+            sc.fgi             = s.get('fgi', 0.0)
+            sc.H_deficit_carry = s.get('H_deficit_carry', 0.0)
+    else:
+        for i, h in enumerate(states['reservoirs']):
+            b.reservoirs[i].Hwater = h
+        if b.has_snowpack:
+            b.snowpack.Hwater = states.get('snowpack', 0.0)
+        b._fgi             = states.get('fgi', 0.0)
+        b.H_deficit_carry  = states.get('H_deficit_carry', 0.0)
+
+
+def _inject_post_spinup_states(b, states):
+    """
+    Inject post-spin-up states, leaving anything not provided at its current
+    (spun-up) value.
+
+    Reservoir entries may be ``None`` to keep that reservoir's spun-up depth;
+    absent ``snowpack``/``fgi`` keep their current values; ``H_deficit_carry``
+    defaults to 0. Accepts the flat or nested form, matching
+    :func:`_capture_states`.
+    """
+    if 'sub_catchments' in states:
+        for sc, s in zip(b.sub_catchments, states['sub_catchments']):
+            for r, h in zip(sc.reservoirs, s.get('reservoirs', [])):
+                if h is not None:
+                    r.Hwater = h
+            if b.has_snowpack and sc.snowpack is not None:
+                sc.snowpack.Hwater = s.get('snowpack', sc.snowpack.Hwater)
+            sc.fgi             = s.get('fgi', sc.fgi)
+            sc.H_deficit_carry = s.get('H_deficit_carry', 0.0)
+    else:
+        for i, h in enumerate(states.get('reservoirs', [])):
+            if h is not None and i < len(b.reservoirs):
+                b.reservoirs[i].Hwater = h
+        if b.has_snowpack:
+            b.snowpack.Hwater = states.get('snowpack', b.snowpack.Hwater)
+        b._fgi             = states.get('fgi', b._fgi)
+        b.H_deficit_carry  = states.get('H_deficit_carry', 0.0)
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -578,25 +669,28 @@ def run_and_score(cfg, recession_coeff=None, f_to_discharge=None, Hmax=None,
         insulation).  Literature values: LISFLOOD uses ~0.057 mm⁻¹;
         GSSHA default is 0.5 (units ambiguous in original source).
     initial_states : dict, optional
-        Starting reservoir water depths, snowpack SWE, and frozen ground
-        index, as returned by a previous call's CalibResult.final_states.
-        Format::
+        Starting reservoir water depths, snowpack SWE, frozen ground index,
+        and carried deficit, as returned by a previous call's
+        CalibResult.final_states.  Flat for a single sub-catchment::
 
             {'reservoirs': [H_shallow, H_deep, ...],
              'snowpack':    H_snow_SWE,
-             'fgi':         frozen_ground_index}
+             'fgi':         frozen_ground_index,
+             'H_deficit_carry': carried_deficit}
 
-        When provided, these override the H0 values from cfg.  Use with
-        spin_up_cycles=0 when chaining consecutive decades so that water
-        storage and frozen-ground state are physically continuous.
-        When None (default), reservoirs are initialised to their
+        or nested under ``'sub_catchments'`` for several (see
+        ``CalibResult.final_states``).  When provided, these override the H0
+        values from cfg.  Use with spin_up_cycles=0 when chaining consecutive
+        decades so that water storage and frozen-ground state are physically
+        continuous.  When None (default), reservoirs are initialised to their
         analytical steady-state depths before spin-up (see
         :func:`_steady_state_depths`).
     post_spinup_states : dict, optional
         Reservoir water depths injected *after* spin-up completes and
         *before* the scored run begins.  Same format as ``initial_states``
-        but only the ``'reservoirs'`` key is used; individual entries may
-        be ``None`` to leave that reservoir at its spin-up end state.
+        (flat, or nested under ``'sub_catchments'``); individual reservoir
+        entries may be ``None`` to leave that reservoir at its spin-up end
+        state, and absent snowpack/FGI keep their spun-up values.
         Intended for calibrating decade-specific initial storage (e.g.
         ``log__H0_deep``) when the spin-up equilibrium is poorly
         constrained by sparse pre-decade forcing.  Only applied in decade
@@ -910,16 +1004,11 @@ def run_and_score(cfg, recession_coeff=None, f_to_discharge=None, Hmax=None,
     # --- Set initial storage states ---
     if initial_states is not None:
         # Analytical or chained initial conditions supplied by the caller.
-        for i, h in enumerate(initial_states['reservoirs']):
-            b.reservoirs[i].Hwater = h
-        if b.has_snowpack:
-            b.snowpack.Hwater = initial_states.get('snowpack', 0.0)
-        b._fgi = initial_states.get('fgi', 0.0)
         # H_deficit_carry can accumulate a large phantom deficit during
         # b.initialize()'s internal spin-up (especially with
-        # enforce_water_balance='none').  Reset it so the decade run starts
-        # cleanly from the specified reservoir depths.
-        b.H_deficit_carry = initial_states.get('H_deficit_carry', 0.0)
+        # enforce_water_balance='none'); _restore_initial_states resets it
+        # (default 0) so the decade run starts cleanly from the given depths.
+        _restore_initial_states(b, initial_states)
     else:
         # Analytical steady-state initialization: correct for reservoirs
         # whose timescale exceeds the record length and accelerates spin-up
@@ -959,13 +1048,7 @@ def run_and_score(cfg, recession_coeff=None, f_to_discharge=None, Hmax=None,
         # the spin-up equilibrium, which may be biased by sparse pre-decade
         # forcing or by candidate parameters far from the decade optimum.
         if post_spinup_states is not None:
-            for i, h in enumerate(post_spinup_states.get('reservoirs', [])):
-                if h is not None and i < len(b.reservoirs):
-                    b.reservoirs[i].Hwater = h
-            if b.has_snowpack:
-                b.snowpack.Hwater = post_spinup_states.get('snowpack', b.snowpack.Hwater)
-            b._fgi = post_spinup_states.get('fgi', b._fgi)
-            b.H_deficit_carry = post_spinup_states.get('H_deficit_carry', 0.0)
+            _inject_post_spinup_states(b, post_spinup_states)
         b.run(start=start, end=end)
     else:
         # Full-record mode: spin up and score on the complete hydrodata.
@@ -977,12 +1060,9 @@ def run_and_score(cfg, recession_coeff=None, f_to_discharge=None, Hmax=None,
         b.run()
 
     # --- Capture end-of-run states for chaining to next decade ---
-    final_states = {
-        'reservoirs':      [res.Hwater for res in b.reservoirs],
-        'snowpack':        b.snowpack.Hwater if b.has_snowpack else 0.0,
-        'fgi':             b._fgi,
-        'H_deficit_carry': b.H_deficit_carry,
-    }
+    # Flat/scalar for a single sub-catchment (back-compatible); nested per
+    # sub-catchment when there are several.
+    final_states = _capture_states(b)
 
     # --- Optional: route total runoff through Nash cascade ---
     # Routing is applied to the full simulation output before the scoring

--- a/mnished/mnished.py
+++ b/mnished/mnished.py
@@ -1089,6 +1089,117 @@ class Buckets(object):
         """
         return [reservoir.Hwater for reservoir in self.reservoirs]
 
+    @staticmethod
+    def _build_reservoir_cascade(res_cfg, H0_list):
+        """
+        Build a vertical reservoir cascade from a "reservoirs" config block.
+
+        Parameters
+        ----------
+        res_cfg : dict
+            A "reservoirs" config block: per-reservoir parameter lists keyed
+            by name (recession_coefficients, exfiltration_fractions, ...). All
+            lists must have the same length as H0_list.
+        H0_list : list of float
+            Initial water depth [mm] for each reservoir, ordered shallowest to
+            deepest. Its length sets the number of reservoirs in the cascade.
+
+        Returns
+        -------
+        list of Reservoir
+            The cascade, ordered shallowest (index 0) to deepest.
+        """
+        n = len(H0_list)
+        for _key, _vals in res_cfg.items():
+            if len(_vals) != n:
+                raise ValueError(
+                    f'"{_key}" within "reservoirs" has {len(_vals)} entries, '
+                    f'implying a different number of subsurface water '
+                    f'reservoirs than the {n} initial water depths '
+                    f'(water_reservoir_effective_depths__mm).')
+
+        _pdm_H0        = res_cfg.get('pdm_H0__mm',               [None]  * n)
+        _f_tile        = res_cfg.get('tile_fractions',           [0.0]   * n)
+        _tau_tile      = res_cfg.get('tile_residence_times__days', [None] * n)
+        _recession_exp = res_cfg.get('recession_exponents',     [1.0]   * n)
+        _junction_types = res_cfg.get('junction_types',     ['fraction'] * n)
+        _leakance_R    = res_cfg.get('leakance_R__days',        [None]  * n)
+        _H_threshold   = res_cfg.get('H_threshold__mm',         [0.0]   * n)
+        _mp_threshold  = res_cfg.get('multipath_thresholds__mm', [None] * n)
+        _mp_timescale  = res_cfg.get('multipath_timescales__days', [None] * n)
+
+        reservoirs = [
+            Reservoir(
+                recession_coeff = res_cfg['recession_coefficients'][i],
+                f_to_discharge  = res_cfg['exfiltration_fractions'][i],
+                Hmax            = res_cfg['maximum_effective_depths__mm'][i],
+                pdm_H0          = _pdm_H0[i],
+                H0              = H0_list[i],
+                f_tile          = _f_tile[i],
+                tau_tile        = _tau_tile[i],
+                junction_type   = _junction_types[i],
+                leakance_R      = _leakance_R[i],
+                H_threshold     = _H_threshold[i] if _H_threshold[i] is not None else 0.0,
+                multipath_threshold = _mp_threshold[i],
+                multipath_timescale = _mp_timescale[i],
+            )
+            for i in range(n)]
+        for i, b_exp in enumerate(_recession_exp):
+            reservoirs[i].recession_exponent = float(b_exp)
+        return reservoirs
+
+    def _build_sub_catchments(self, sc_cfgs):
+        """
+        Build the list of parallel SubCatchments from a "sub_catchments" config.
+
+        Parameters
+        ----------
+        sc_cfgs : list of dict
+            One entry per sub-catchment. Each requires a unique ``name``, an
+            ``area_fraction``, and a ``reservoirs`` block (same schema as the
+            top-level legacy block). An optional ``initial_conditions`` block
+            supplies per-reservoir initial depths
+            (water_reservoir_effective_depths__mm); absent depths default to 0.
+            A ``forcing`` block is reserved for a future release and raises
+            NotImplementedError if present.
+
+        Returns
+        -------
+        list of SubCatchment
+
+        Raises
+        ------
+        ValueError
+            If names are not unique, or the area fractions do not sum to 1.
+        """
+        if not isinstance(sc_cfgs, list) or len(sc_cfgs) < 1:
+            raise ValueError(
+                '"sub_catchments" must be a non-empty list of sub-catchment '
+                'definitions.')
+
+        _names = [sc['name'] for sc in sc_cfgs]
+        if len(set(_names)) != len(_names):
+            raise ValueError(
+                f'Sub-catchment names must be unique; got {_names}.')
+
+        _area_sum = sum(sc['area_fraction'] for sc in sc_cfgs)
+        if abs(_area_sum - 1.0) > 1e-6:
+            raise ValueError(
+                f'Sub-catchment area_fraction values must sum to 1.0; '
+                f'got {_area_sum:.6f}.')
+
+        sub_catchments = []
+        for sc in sc_cfgs:
+            _res_cfg = sc['reservoirs']
+            _ic = sc.get('initial_conditions', {})
+            _n = len(_res_cfg['recession_coefficients'])
+            _H0 = _ic.get('water_reservoir_effective_depths__mm', [0.0] * _n)
+            _reservoirs = self._build_reservoir_cascade(_res_cfg, _H0)
+            sub_catchments.append(
+                SubCatchment(sc['name'], sc['area_fraction'], _reservoirs,
+                             forcing=sc.get('forcing')))
+        return sub_catchments
+
     def initialize(self, config_file=None, enforce_water_balance=None):
         """
         Set up the model from a YAML configuration file.
@@ -1148,67 +1259,26 @@ class Buckets(object):
             self.cfg['timeseries']['datafile'],
             parse_dates=['Date'])
 
-        # Set variables on reservoirs
-        # First, check if all reservoirs have the same length
-        for _key in self.cfg['reservoirs'].keys():
-            if len(self.cfg['reservoirs'][_key]) == \
-                    len(self.cfg['initial_conditions']['water_reservoir_effective_depths__mm']):
-                pass
-            else:
-                raise ValueError(_key + ' within "reservoirs" contains a\n'+
-                                 'different number of entries, implying'+
-                                 'a different number of subsurface water\n'+
-                                 'reservoirs, than '+
-                                 'water_reservoir_effective_depths__mm'+
-                                 ' within "initial_conditions".')
-
-        # If all are the same length, then we will assign a number of reservoirs
-        self.n_reservoirs = len(
-            self.cfg['initial_conditions']['water_reservoir_effective_depths__mm'])
-        # Using this, we will build a list of reservoir objects
-        # and initialize them based on the provided inputs
-        _pdm_H0        = self.cfg['reservoirs'].get('pdm_H0__mm',
-                                                    [None]  * self.n_reservoirs)
-        _f_tile        = self.cfg['reservoirs'].get('tile_fractions',
-                                                    [0.0]   * self.n_reservoirs)
-        _tau_tile      = self.cfg['reservoirs'].get('tile_residence_times__days',
-                                                    [None]  * self.n_reservoirs)
-        _recession_exp = self.cfg['reservoirs'].get('recession_exponents',
-                                                    [1.0]   * self.n_reservoirs)
-        _junction_types   = self.cfg['reservoirs'].get('junction_types',
-                                                    ['fraction'] * self.n_reservoirs)
-        _leakance_R       = self.cfg['reservoirs'].get('leakance_R__days',
-                                                    [None]  * self.n_reservoirs)
-        _H_threshold      = self.cfg['reservoirs'].get('H_threshold__mm',
-                                                    [0.0]   * self.n_reservoirs)
-        _mp_threshold     = self.cfg['reservoirs'].get('multipath_thresholds__mm',
-                                                    [None]  * self.n_reservoirs)
-        _mp_timescale     = self.cfg['reservoirs'].get('multipath_timescales__days',
-                                                    [None]  * self.n_reservoirs)
-        _basin_reservoirs = [
-            Reservoir(
-                recession_coeff = self.cfg['reservoirs']['recession_coefficients'][i],
-                f_to_discharge = self.cfg['reservoirs']['exfiltration_fractions'][i],
-                Hmax           = self.cfg['reservoirs']['maximum_effective_depths__mm'][i],
-                pdm_H0         = _pdm_H0[i],
-                H0             = self.cfg['initial_conditions'][
-                    'water_reservoir_effective_depths__mm'][i],
-                f_tile         = _f_tile[i],
-                tau_tile       = _tau_tile[i],
-                junction_type  = _junction_types[i],
-                leakance_R     = _leakance_R[i],
-                H_threshold    = _H_threshold[i] if _H_threshold[i] is not None else 0.0,
-                multipath_threshold = _mp_threshold[i],
-                multipath_timescale = _mp_timescale[i],
-            )
-            for i in range(self.n_reservoirs)]
-        # The legacy single-cascade configuration is one sub-catchment covering
-        # the whole basin (area_fraction = 1.0); self.reservoirs (a property)
-        # then exposes the same flat cascade as before. Multi-sub-catchment
-        # YAML parsing is added in a following commit.
-        self.sub_catchments = [SubCatchment('basin', 1.0, _basin_reservoirs)]
-        for i, b_exp in enumerate(_recession_exp):
-            self.reservoirs[i].recession_exponent = float(b_exp)
+        # Build the sub-catchment structure. A config may either give a single
+        # basin-wide reservoir cascade (legacy: top-level "reservoirs" +
+        # "initial_conditions" blocks) or partition the basin into parallel
+        # "sub_catchments", each with its own cascade. The legacy form is
+        # promoted to one sub-catchment of area_fraction 1.0, which reproduces
+        # the original behaviour exactly (self.reservoirs then exposes the same
+        # flat cascade as before).
+        if 'sub_catchments' in self.cfg:
+            self.sub_catchments = self._build_sub_catchments(
+                self.cfg['sub_catchments'])
+        else:
+            _basin_reservoirs = self._build_reservoir_cascade(
+                self.cfg['reservoirs'],
+                self.cfg['initial_conditions'][
+                    'water_reservoir_effective_depths__mm'])
+            self.sub_catchments = [
+                SubCatchment('basin', 1.0, _basin_reservoirs)]
+        # Total reservoir count across all sub-catchments (informational;
+        # equals the legacy single-cascade length when there is one sub-catchment).
+        self.n_reservoirs = len(self.reservoirs)
 
         # Check if bottom reservoir discharges all to river: conserve mass.
         # But allow through with a warning in case the user wants a

--- a/mnished/mnished.py
+++ b/mnished/mnished.py
@@ -998,9 +998,9 @@ class Buckets(object):
 
         # Frozen ground index (Molnau & Bissell 1983).  Disabled by default
         # (threshold = inf); overridden by snowmelt.fdd_threshold in YAML or
-        # by run_and_score(fdd_threshold=).
+        # by run_and_score(fdd_threshold=).  The FGI state itself lives on each
+        # sub-catchment (SubCatchment.fgi), created in initialize().
         self.fdd_threshold = np.inf  # [°C·day]
-        self._fgi          = 0.0    # current frozen ground index [°C·day]
 
     @property
     def reservoirs(self):
@@ -1032,6 +1032,52 @@ class Buckets(object):
     def n_sub_catchments(self):
         """Number of parallel sub-catchments (>= 1)."""
         return len(self.sub_catchments)
+
+    @property
+    def snowpack(self):
+        """
+        Snowpack of the first sub-catchment (the whole basin when there is a
+        single sub-catchment). For per-sub-catchment snowpacks, iterate
+        ``sub_catchments``. Read-only; snowpacks are created in initialize().
+        """
+        return self.sub_catchments[0].snowpack
+
+    @property
+    def _fgi(self):
+        """
+        Frozen-ground index of the first sub-catchment [°C·day]. For
+        per-sub-catchment FGI, see ``sub_catchments``. The state is advanced
+        per sub-catchment by _update_fgi(); the setter broadcasts a scalar to
+        every sub-catchment (used to restore or reset single-sub-catchment
+        calibration state).
+        """
+        return self.sub_catchments[0].fgi
+
+    @_fgi.setter
+    def _fgi(self, value):
+        for sc in self.sub_catchments:
+            sc.fgi = value
+
+    @property
+    def H_deficit_carry(self):
+        """
+        Basin recharge deficit carried into the next time step [mm], as the
+        area-weighted sum over sub-catchments (so the basin mass balance is
+        exact at any number of sub-catchments). The per-sub-catchment deficits
+        are stored on each SubCatchment.
+
+        The setter broadcasts a scalar to every sub-catchment; because the area
+        fractions sum to 1, the area-weighted getter then returns that same
+        value, so a set/get round-trips. Used to restore or reset state in
+        single-sub-catchment calibration.
+        """
+        return sum(sc.area_fraction * sc.H_deficit_carry
+                   for sc in self.sub_catchments)
+
+    @H_deficit_carry.setter
+    def H_deficit_carry(self, value):
+        for sc in self.sub_catchments:
+            sc.H_deficit_carry = value
 
     def _compute_Chang_I(self, T_monthly_normals):
         """
@@ -1358,12 +1404,11 @@ class Buckets(object):
                             'Minimum Temperature [C]' in self.hydrodata.columns and
                             'Maximum Temperature [C]' in self.hydrodata.columns)
         if self.has_snowpack:
-            # Instantiate snowpack
-            self.snowpack = Snowpack(self.melt_factor)  # allow changes to melt factor later
-            # Mirror onto the sub-catchment(s); the time loops still read the
-            # basin-level self.snowpack until per-sub-catchment state is wired in.
+            # Each sub-catchment gets its own snowpack so that per-sub-catchment
+            # forcing can drive them independently later. With basin-shared
+            # forcing they evolve identically. self.snowpack aliases the first.
             for sc in self.sub_catchments:
-                sc.snowpack = self.snowpack
+                sc.snowpack = Snowpack(self.melt_factor)
         elif 'Mean Temperature [C]' in self.hydrodata.columns and not self.use_snowpack:
             pass  # snowpack deliberately disabled via modules config
         else:
@@ -1396,10 +1441,19 @@ class Buckets(object):
         self.direct_runoff_fraction = self.cfg['general'].get(
             'direct_runoff_fraction', 0.0)
 
-        # Initial conditions if resuming from prior run
+        # Initial conditions if resuming from prior run. Each sub-catchment
+        # takes its initial SWE from its own initial_conditions block; the
+        # legacy single-cascade config uses the top-level initial_conditions.
         if self.has_snowpack:
-            self.snowpack.Hwater = self.cfg['initial_conditions']['snowpack__mm_SWE']
-        # Reservoir H0 values are set in the list comprehension above.
+            if 'sub_catchments' in self.cfg:
+                for sc, sc_cfg in zip(self.sub_catchments,
+                                      self.cfg['sub_catchments']):
+                    sc.snowpack.Hwater = sc_cfg.get('initial_conditions', {}).get(
+                        'snowpack__mm_SWE', 0.0)
+            else:
+                self.sub_catchments[0].snowpack.Hwater = (
+                    self.cfg['initial_conditions']['snowpack__mm_SWE'])
+        # Reservoir H0 values are set during sub-catchment construction.
 
         # Enforce the daily timestep. MNiShed is a daily model by design:
         # degree-day snowmelt, Thornthwaite ET, and linear reservoir drainage
@@ -1435,8 +1489,11 @@ class Buckets(object):
         # Carry-over of any water deficit from the previous timestep that the
         # deepest reservoir could not satisfy (ET > P + all storage).  This is
         # the unpaid debt passed forward one step; distinct from
-        # Reservoir.H_deficit and Snowpack.H_deficit, which are per-timestep only.
-        self.H_deficit_carry = 0.
+        # Reservoir.H_deficit and Snowpack.H_deficit, which are per-timestep
+        # only. Stored per sub-catchment; self.H_deficit_carry reads the
+        # area-weighted sum.
+        for sc in self.sub_catchments:
+            sc.H_deficit_carry = 0.
 
         # Compute the water years based on the input month for
         # water-year rollover
@@ -1641,28 +1698,34 @@ class Buckets(object):
         # land-cover or climate sensitivity — at the cost of exact WB closure.
         self.hydrodata['ET for model [mm/day]'] = _et_mode * self.et_scale
 
-    def _et_stress_factor(self):
+    def _et_stress_factor(self, sub_catchment):
         """
         Water-availability multiplier applied to potential ET each time step.
 
         Returns 1 - exp(-H_shallow / H0), where H_shallow is the current water
-        depth in the shallowest reservoir and H0 is its PDM characteristic
-        storage depth (pdm_H0).  The multiplier is zero when the reservoir is
-        empty and approaches 1 as it fills, so actual ET = potential ET * factor.
+        depth in the sub-catchment's shallowest reservoir and H0 is its PDM
+        characteristic storage depth (pdm_H0).  The multiplier is zero when the
+        reservoir is empty and approaches 1 as it fills, so actual ET =
+        potential ET * factor.
 
         Returns 1.0 (no stress) when et_water_stress is disabled or when the
         shallow reservoir has no pdm_H0 set.
+
+        Parameters
+        ----------
+        sub_catchment : SubCatchment
+            The sub-catchment whose shallow reservoir governs the stress.
         """
         if not self.use_et_water_stress:
             return 1.0
-        H0 = self.reservoirs[0].pdm_H0
+        H0 = sub_catchment.reservoirs[0].pdm_H0
         if H0 is None:
             return 1.0
-        return 1.0 - np.exp(-max(self.reservoirs[0].Hwater, 0.0) / H0)
+        return 1.0 - np.exp(-max(sub_catchment.reservoirs[0].Hwater, 0.0) / H0)
 
-    def _draw_et_from_reservoirs(self, ET_pot):
+    def _draw_et_from_reservoirs(self, ET_pot, sub_catchment=None):
         """
-        Remove actual ET from reservoirs after cascade drainage.
+        Remove actual ET from a sub-catchment's reservoirs after drainage.
 
         ET_pot is partitioned between reservoir 0 (shallow) and reservoir 1
         (soil) by et_alpha.  Each draw is capped at available storage so
@@ -1677,6 +1740,9 @@ class Buckets(object):
         ET_pot : float
             Potential ET for this time step [mm/day], already scaled by
             et_scale or the global water-balance multiplier.
+        sub_catchment : SubCatchment, optional
+            The sub-catchment to draw from. Defaults to the first
+            sub-catchment (the whole basin in the single-sub-catchment case).
 
         Returns
         -------
@@ -1685,13 +1751,16 @@ class Buckets(object):
             a reservoir's Hmax.  Zero in the usual (ET removal) case; the
             caller adds it to the day's discharge.
         """
+        if sub_catchment is None:
+            sub_catchment = self.sub_catchments[0]
+        reservoirs = sub_catchment.reservoirs
         fractions = [self.et_alpha, 1.0 - self.et_alpha]
         excess = 0.0
         for i, frac in enumerate(fractions):
-            if i >= len(self.reservoirs):
+            if i >= len(reservoirs):
                 break
             demand = frac * ET_pot
-            H = self.reservoirs[i].Hwater
+            H = reservoirs[i].Hwater
             if i == 1 and self.wp_soil > 0.0:
                 # Soil reservoir: scale demand by fraction of catchment above WP.
                 if self.wp_soil_sigma > 0.0:
@@ -1705,20 +1774,28 @@ class Buckets(object):
                         continue
                     H = H - self.wp_soil   # only water above WP is available
             actual = min(demand, max(0.0, H))
-            self.reservoirs[i].Hwater -= actual
+            reservoirs[i].Hwater -= actual
             # Condensation (negative ET) that overtops the cap runs off.
-            if self.reservoirs[i].Hwater > self.reservoirs[i].Hmax:
-                excess += self.reservoirs[i].Hwater - self.reservoirs[i].Hmax
-                self.reservoirs[i].Hwater = self.reservoirs[i].Hmax
+            if reservoirs[i].Hwater > reservoirs[i].Hmax:
+                excess += reservoirs[i].Hwater - reservoirs[i].Hmax
+                reservoirs[i].Hwater = reservoirs[i].Hmax
         return excess
 
-    def _compute_snowpack(self, time_step):
+    def _compute_snowpack(self, time_step, sub_catchment):
         """
-        Update the snowpack for one timestep; return excess melt energy.
+        Update a sub-catchment's snowpack for one timestep; return excess melt.
 
         Sets temperature, applies net water input, then calls melt() with
         the raw precipitation so rain-on-snow sensible heat is included.
-        Updates self.H_deficit_carry from the snowpack before returning.
+        Updates the sub-catchment's H_deficit_carry from the snowpack before
+        returning.
+
+        Parameters
+        ----------
+        time_step : int
+            Current row index in self.hydrodata.
+        sub_catchment : SubCatchment
+            The sub-catchment whose snowpack is advanced.
 
         Returns
         -------
@@ -1726,23 +1803,24 @@ class Buckets(object):
             Leftover melt energy [°C·day] after SWE is fully depleted.
             Pass to _update_fgi() to credit toward frozen-soil thawing.
         """
+        snowpack = sub_catchment.snowpack
         T = self.hydrodata['Mean Temperature [C]'][time_step]
         P = self.hydrodata['Precipitation [mm/day]'][time_step]
-        self.snowpack.set_temperature(T)
+        snowpack.set_temperature(T)
         if self.use_et_reservoir_draw:
-            _sp_recharge = P + self.H_deficit_carry
+            _sp_recharge = P + sub_catchment.H_deficit_carry
         else:
             _sp_recharge = (P
                             - self.hydrodata['ET for model [mm/day]'][time_step]
-                            * self._et_stress_factor()
-                            + self.H_deficit_carry)
-        self.snowpack.recharge(_sp_recharge)
-        excess_dd = self.snowpack.melt(self.dt,
-                                       P=(P if self.use_rain_on_snow else 0.0))
-        self.H_deficit_carry = self.snowpack.H_deficit
+                            * self._et_stress_factor(sub_catchment)
+                            + sub_catchment.H_deficit_carry)
+        snowpack.recharge(_sp_recharge)
+        excess_dd = snowpack.melt(self.dt,
+                                  P=(P if self.use_rain_on_snow else 0.0))
+        sub_catchment.H_deficit_carry = snowpack.H_deficit
         return excess_dd
 
-    def _update_fgi(self, time_step, excess_dd=0.0):
+    def _update_fgi(self, time_step, sub_catchment, excess_dd=0.0):
         """
         Update the frozen ground index; flag top reservoir as frozen if needed.
 
@@ -1792,6 +1870,8 @@ class Buckets(object):
         ----------
         time_step : int
             Current row index in self.hydrodata.
+        sub_catchment : SubCatchment
+            The sub-catchment whose FGI and top reservoir are updated.
         excess_dd : float, optional
             Degree-day equivalent of leftover melt energy from
             _compute_snowpack() [°C·day]. Reduces FGI alongside air
@@ -1808,7 +1888,7 @@ class Buckets(object):
             Calibrated f_to_discharge of the top reservoir, saved before any
             frozen-ground override. Restore it after the discharge loop.
         """
-        f0 = self.reservoirs[0].f_to_discharge
+        f0 = sub_catchment.reservoirs[0].f_to_discharge
         if not self.use_frozen_ground or np.isinf(self.fdd_threshold):
             return f0
 
@@ -1817,8 +1897,10 @@ class Buckets(object):
                 "fdd_threshold is set but 'Mean Temperature [C]' is missing "
                 "from the input data. FGI requires temperature data."
             )
+        _swe  = (sub_catchment.snowpack.Hwater
+                 if sub_catchment.snowpack is not None else 0.0)
         T     = self.hydrodata['Mean Temperature [C]'][time_step]
-        T_eff = T * np.exp(-self.snow_insulation_k * self.snowpack.Hwater)
+        T_eff = T * np.exp(-self.snow_insulation_k * _swe)
 
         if self._has_trange:
             T_max = self.hydrodata['Maximum Temperature [C]'][time_step]
@@ -1832,20 +1914,118 @@ class Buckets(object):
         else:
             A_t = self.fgi_decay_coeff
 
-        self._fgi = max(0.0, A_t * self._fgi - T_eff - excess_dd)
-        if self._fgi > self.fdd_threshold:
-            self.reservoirs[0].f_to_discharge = 1.0
+        sub_catchment.fgi = max(0.0, A_t * sub_catchment.fgi - T_eff - excess_dd)
+        if sub_catchment.fgi > self.fdd_threshold:
+            sub_catchment.reservoirs[0].f_to_discharge = 1.0
         return f0
+
+    @staticmethod
+    def _sub_catchment_storage(sub_catchment):
+        """
+        Total subsurface storage [mm] in a sub-catchment: reservoir water plus
+        any tile-drain sub-reservoir water.
+        """
+        return (sum(r.Hwater for r in sub_catchment.reservoirs)
+                + sum(r.tile_res.Hwater for r in sub_catchment.reservoirs
+                      if r.tile_res is not None))
+
+    def _advance_sub_catchment(self, time_step, sub_catchment):
+        """
+        Advance one sub-catchment by a single time step.
+
+        Runs the snowpack, frozen-ground index, the vertical reservoir cascade,
+        and reservoir-draw ET for this sub-catchment, mutating its state in
+        place. Forcing is read from the basin-level columns of self.hydrodata.
+
+        Parameters
+        ----------
+        time_step : int
+            Row index in self.hydrodata for this step.
+        sub_catchment : SubCatchment
+            The sub-catchment to advance.
+
+        Returns
+        -------
+        qi : float
+            Per-unit-area specific discharge from this sub-catchment [mm/day],
+            unweighted by area fraction.
+        flux_direct, flux_tile, flux_multipath : float
+            Per-unit-area flux-partition components [mm/day]: direct runoff,
+            tile drainage, and multipath drainage.
+        """
+        reservoirs = sub_catchment.reservoirs
+        excess_dd = (self._compute_snowpack(time_step, sub_catchment)
+                     if self.has_snowpack else 0.0)
+        f0 = self._update_fgi(time_step, sub_catchment, excess_dd)
+
+        qi = 0.0
+        for i in range(len(reservoirs)):
+            if i == 0:
+                if self.has_snowpack:
+                    _recharge = (sub_catchment.snowpack.H_infiltrated
+                                 + sub_catchment.H_deficit_carry)
+                else:
+                    if self.use_et_reservoir_draw:
+                        _recharge = (
+                            self.hydrodata['Precipitation [mm/day]'][time_step] +
+                            sub_catchment.H_deficit_carry)
+                    else:
+                        _recharge = (
+                            self.hydrodata['Precipitation [mm/day]'][time_step] -
+                            self.hydrodata['ET for model [mm/day]'][time_step]
+                            * self._et_stress_factor(sub_catchment) +
+                            sub_catchment.H_deficit_carry)
+                # Hortonian-inspired bypass: fraction exits without entering reservoirs.
+                _q_direct = (max(0.0, _recharge) * self.direct_runoff_fraction
+                             if self.use_direct_runoff else 0.0)
+                qi += _q_direct
+                reservoirs[i].recharge(_recharge - _q_direct)
+            else:
+                # Let water infiltrate to lower layers effectively
+                # instantaneously; this isn't quite realistic, but
+                # should be a simpler approach for parameter calibration
+                # (Plus, this is just the water that did exit that above
+                # container, which is already free to discharge, so this
+                # seems more self-consistent.)
+                # The amount of infiltrated water from above could be
+                # negative; this represents ET in excess of what the
+                # unsaturated zone ("soil zone"; top reservoir) holds.
+                # Deeper loss of water could be due to plants tapping into
+                # groundwater, direct lake evaporation, etc. -- or related
+                # to this model not being physical or distributed, so just
+                # needing to balance mass.
+                reservoirs[i].recharge(
+                    reservoirs[i-1].H_to_next
+                    + reservoirs[i-1].H_deficit)
+            H_next = (reservoirs[i + 1].Hwater
+                      if i + 1 < len(reservoirs) else None)
+            reservoirs[i].discharge(self.dt, H_next=H_next)
+            qi += reservoirs[i].H_discharge
+
+        reservoirs[0].f_to_discharge = f0
+        sub_catchment.H_deficit_carry = reservoirs[-1].H_deficit
+
+        flux_direct    = _q_direct
+        flux_tile      = sum(r.H_tile for r in reservoirs)
+        flux_multipath = sum(r.H_multipath for r in reservoirs)
+
+        if self.use_et_reservoir_draw:
+            qi += self._draw_et_from_reservoirs(
+                self.hydrodata['ET for model [mm/day]'][time_step],
+                sub_catchment)
+
+        return qi, flux_direct, flux_tile, flux_multipath
 
     def update(self, time_step=None):
         """
         Advance the model by one time step.
 
-        Routes precipitation minus ET through the snowpack (if present) and
-        then through each subsurface reservoir in order from shallowest to
-        deepest. Stores modeled specific discharge, snowpack SWE, and total
-        subsurface storage in self.hydrodata for the current time step.
-        Part of the CSDMS Basic Model Interface.
+        Advances each parallel sub-catchment (snowpack, frozen ground, and its
+        reservoir cascade from shallowest to deepest) and aggregates them to
+        basin means, weighting per-unit-area quantities by sub-catchment area
+        fraction. Stores modeled specific discharge, snowpack SWE, and total
+        subsurface storage in self.hydrodata for the current time step. Part of
+        the CSDMS Basic Model Interface.
 
         Parameters
         ----------
@@ -1873,86 +2053,48 @@ class Buckets(object):
             self.hydrodata.at[time_step,
                               'Specific Discharge (modeled) [mm/day]'] = np.nan
             if self.has_snowpack:
-                self.hydrodata.at[time_step, 'Snowpack (modeled) [mm SWE]'] = (
-                    self.snowpack.Hwater)
+                self.hydrodata.at[time_step, 'Snowpack (modeled) [mm SWE]'] = sum(
+                    sc.area_fraction * sc.snowpack.Hwater
+                    for sc in self.sub_catchments)
             self.hydrodata.at[time_step,
-                              'Subsurface storage (modeled total) [mm]'] = (
-                np.sum([res.Hwater for res in self.reservoirs])
-                + np.sum([res.tile_res.Hwater for res in self.reservoirs
-                          if res.tile_res is not None]))
+                              'Subsurface storage (modeled total) [mm]'] = sum(
+                sc.area_fraction * self._sub_catchment_storage(sc)
+                for sc in self.sub_catchments)
             self._flux_direct_runoff = np.nan
             self._flux_tile = np.nan
             self._flux_multipath = np.nan
             return
 
-        excess_dd = self._compute_snowpack(time_step) if self.has_snowpack else 0.0
-        f0 = self._update_fgi(time_step, excess_dd)
-
-        qi = 0.0
-        for i in range(len(self.reservoirs)):
-            if i == 0:
-                if self.has_snowpack:
-                    _recharge = (self.snowpack.H_infiltrated
-                                 + self.H_deficit_carry)
-                else:
-                    if self.use_et_reservoir_draw:
-                        _recharge = (
-                            self.hydrodata['Precipitation [mm/day]'][time_step] +
-                            self.H_deficit_carry)
-                    else:
-                        _recharge = (
-                            self.hydrodata['Precipitation [mm/day]'][time_step] -
-                            self.hydrodata['ET for model [mm/day]'][time_step]
-                            * self._et_stress_factor() +
-                            self.H_deficit_carry)
-                # Hortonian-inspired bypass: fraction exits without entering reservoirs.
-                _q_direct = (max(0.0, _recharge) * self.direct_runoff_fraction
-                             if self.use_direct_runoff else 0.0)
-                qi += _q_direct
-                self.reservoirs[i].recharge(_recharge - _q_direct)
-            else:
-                # Let water infiltrate to lower layers effectively
-                # instantaneously; this isn't quite realistic, but
-                # should be a simpler approach for parameter calibration
-                # (Plus, this is just the water that did exit that above
-                # container, which is already free to discharge, so this
-                # seems more self-consistent.)
-                # The amount of infiltrated water from above could be
-                # negative; this represents ET in excess of what the
-                # unsaturated zone ("soil zone"; top reservoir) holds.
-                # Deeper loss of water could be due to plants tapping into
-                # groundwater, direct lake evaporation, etc. -- or related
-                # to this model not being physical or distributed, so just
-                # needing to balance mass.
-                self.reservoirs[i].recharge(
-                    self.reservoirs[i-1].H_to_next
-                    + self.reservoirs[i-1].H_deficit)
-            H_next = (self.reservoirs[i + 1].Hwater
-                      if i + 1 < len(self.reservoirs) else None)
-            self.reservoirs[i].discharge(self.dt, H_next=H_next)
-            qi += self.reservoirs[i].H_discharge
-
-        self.reservoirs[0].f_to_discharge = f0
-        self.H_deficit_carry = self.reservoirs[-1].H_deficit
+        qi             = 0.0
+        swe            = 0.0
+        storage        = 0.0
+        flux_direct    = 0.0
+        flux_tile      = 0.0
+        flux_multipath = 0.0
+        for sc in self.sub_catchments:
+            a = sc.area_fraction
+            qi_sc, dr_sc, tile_sc, mp_sc = self._advance_sub_catchment(
+                time_step, sc)
+            qi             += a * qi_sc
+            if self.has_snowpack:
+                swe        += a * sc.snowpack.Hwater
+            storage        += a * self._sub_catchment_storage(sc)
+            flux_direct    += a * dr_sc
+            flux_tile      += a * tile_sc
+            flux_multipath += a * mp_sc
 
         # Record per-step flux-partition components (mm/day) for diagnostics
         # and BMI coupling.  These are already reflected in the total
         # specific discharge above; recording them changes no result.
-        self._flux_direct_runoff = _q_direct
-        self._flux_tile = sum(r.H_tile for r in self.reservoirs)
-        self._flux_multipath = sum(r.H_multipath for r in self.reservoirs)
-
-        if self.use_et_reservoir_draw:
-            qi += self._draw_et_from_reservoirs(
-                self.hydrodata['ET for model [mm/day]'][time_step])
+        self._flux_direct_runoff = flux_direct
+        self._flux_tile          = flux_tile
+        self._flux_multipath     = flux_multipath
 
         self.hydrodata.at[time_step, 'Specific Discharge (modeled) [mm/day]'] = qi
         if self.has_snowpack:
-            self.hydrodata.at[time_step, 'Snowpack (modeled) [mm SWE]'] = self.snowpack.Hwater
-        self.hydrodata.at[time_step, 'Subsurface storage (modeled total) [mm]'] = (
-            np.sum([res.Hwater for res in self.reservoirs])
-            + np.sum([res.tile_res.Hwater for res in self.reservoirs
-                      if res.tile_res is not None]))
+            self.hydrodata.at[time_step, 'Snowpack (modeled) [mm SWE]'] = swe
+        self.hydrodata.at[time_step,
+                          'Subsurface storage (modeled total) [mm]'] = storage
         if self._store_depths:
             for _i, _res in enumerate(self.reservoirs):
                 self.hydrodata.at[time_step,
@@ -2129,10 +2271,14 @@ class Buckets(object):
             for _i, _r in enumerate(self.reservoirs):
                 if _r.tile_res is not None:
                     _r.tile_res.Hwater = float(_finalHTile[_i])
+            # The JIT path runs a single sub-catchment; write its final state
+            # back to the first (only) sub-catchment. (Multi-sub-catchment JIT
+            # support is added in a following commit.)
+            _sc0 = self.sub_catchments[0]
             if self.has_snowpack:
-                self.snowpack.Hwater = float(_finalSnow)
-            self._fgi            = float(_finalFgi)
-            self.H_deficit_carry = float(_finalDC)
+                _sc0.snowpack.Hwater = float(_finalSnow)
+            _sc0.fgi             = float(_finalFgi)
+            _sc0.H_deficit_carry = float(_finalDC)
 
         elif _run_idx is not None:
             for i in _run_idx:

--- a/mnished/mnished.py
+++ b/mnished/mnished.py
@@ -1174,6 +1174,24 @@ class Buckets(object):
         """
         return [reservoir.Hwater for reservoir in self.reservoirs]
 
+    def _depth_column_names(self):
+        """
+        Column names for per-reservoir stored depths (``store_depths=True``),
+        aligned with the flat :attr:`reservoirs` order.
+
+        A single sub-catchment keeps the legacy ``'H_reservoir_{i} (modeled)
+        [mm]'`` names. With several sub-catchments the names are prefixed with
+        the sub-catchment name and use the reservoir's index *within* that
+        sub-catchment, e.g. ``'H_till_uplands_reservoir_0 (modeled) [mm]'``,
+        so each depth column is unambiguously attributable to a zone.
+        """
+        if self.n_sub_catchments == 1:
+            return [f'H_reservoir_{i} (modeled) [mm]'
+                    for i in range(len(self.sub_catchments[0].reservoirs))]
+        return [f'H_{sc.name}_reservoir_{j} (modeled) [mm]'
+                for sc in self.sub_catchments
+                for j in range(len(sc.reservoirs))]
+
     @staticmethod
     def _build_reservoir_cascade(res_cfg, H0_list):
         """
@@ -2135,9 +2153,8 @@ class Buckets(object):
         self.hydrodata.at[time_step,
                           'Subsurface storage (modeled total) [mm]'] = storage
         if self._store_depths:
-            for _i, _res in enumerate(self.reservoirs):
-                self.hydrodata.at[time_step,
-                                  f'H_reservoir_{_i} (modeled) [mm]'] = _res.Hwater
+            for _res, _col in zip(self.reservoirs, self._depth_column_names()):
+                self.hydrodata.at[time_step, _col] = _res.Hwater
 
     def evapotranspiration_Chang2019(self, Tmax=None, Tmin=None, photoperiod=None,
                                     k=0.69):
@@ -2231,8 +2248,8 @@ class Buckets(object):
 
         self._store_depths = store_depths
         if store_depths:
-            for _i in range(len(self.reservoirs)):
-                self.hydrodata[f'H_reservoir_{_i} (modeled) [mm]'] = pd.NA
+            for _col in self._depth_column_names():
+                self.hydrodata[_col] = pd.NA
 
         # JIT path: available when numba is installed, no PDM,
         # and no et_water_stress (which requires pdm_H0 logic not in the JIT).
@@ -2329,8 +2346,8 @@ class Buckets(object):
                 self.hydrodata.loc[_idx, 'Snowpack (modeled) [mm SWE]'] = _SWE
             self.hydrodata.loc[_idx, 'Subsurface storage (modeled total) [mm]'] = _Hsub
             if store_depths:
-                for _i in range(len(self.reservoirs)):
-                    self.hydrodata.loc[_idx, f'H_reservoir_{_i} (modeled) [mm]'] = _Hres_out[:, _i]
+                for _i, _col in enumerate(self._depth_column_names()):
+                    self.hydrodata.loc[_idx, _col] = _Hres_out[:, _i]
             for _i, _h in enumerate(_finalH):
                 self.reservoirs[_i].Hwater = float(_h)
             for _i, _r in enumerate(self.reservoirs):

--- a/mnished/mnished.py
+++ b/mnished/mnished.py
@@ -41,6 +41,7 @@ _CP_LF = 4186.0 / 334000.0
 if _numba_available:
     @_numba.jit(nopython=True, cache=True)
     def _jit_run(P_arr, ET_arr, T_arr, T_min_arr, T_max_arr,
+                 sc_start_idx, sc_end_idx, sc_area_fractions,
                  H_init, H_snow_init, fgi_init, H_deficit_carry_init,
                  tau_arr, b_arr, H_ref_arr, f_dis_in, junction_arr,
                  leakance_R_arr, H_threshold_arr, Hmax_arr,
@@ -52,9 +53,18 @@ if _numba_available:
                  use_direct_runoff, has_trange):
         """JIT-compiled daily time loop replacing Buckets.run()/update().
 
-        Replicates update()/_compute_snowpack()/_update_fgi()/
-        _draw_et_from_reservoirs() exactly for the common case (no PDM,
-        no et_water_stress).  Falls back to the Python loop otherwise.
+        Replicates update()/_advance_sub_catchment()/_compute_snowpack()/
+        _update_fgi()/_draw_et_from_reservoirs() exactly for the common case
+        (no PDM, no et_water_stress).  Falls back to the Python loop otherwise.
+
+        Parallel sub-catchments are flattened into the per-reservoir arrays;
+        ``sc_start_idx[k]``/``sc_end_idx[k]`` give the half-open reservoir-index
+        range of sub-catchment *k*, and ``sc_area_fractions[k]`` its basin-area
+        weight. Snowpack SWE, FGI, and the carried deficit are per-sub-catchment
+        (``H_snow_init``/``fgi_init``/``H_deficit_carry_init`` are length-n_sub
+        arrays). Basin discharge, SWE, and storage are the area-weighted means
+        over sub-catchments. A single sub-catchment (area 1.0) reproduces the
+        original behaviour exactly.
 
         Two tile-drain mechanisms are supported (independently or together):
           - Constant-fraction bypass (``f_tile_arr``/``tau_tile_arr``):
@@ -70,21 +80,23 @@ if _numba_available:
         """
         n_steps = len(P_arr)
         n_res   = len(tau_arr)
+        n_sub   = len(sc_start_idx)
 
         Q_out     = np.empty(n_steps)
         SWE_out   = np.empty(n_steps)
         H_sub_out = np.empty(n_steps)
         H_res_out = np.empty((n_steps, n_res))
 
-        H_res            = H_init.copy()
-        H_snow_cur       = H_snow_init
-        fgi_cur          = fgi_init
-        H_deficit_carry  = H_deficit_carry_init
+        H_res  = H_init.copy()
+        H_snow = H_snow_init.copy()             # per-sub-catchment SWE [mm]
+        fgi    = fgi_init.copy()                 # per-sub-catchment FGI [°C·day]
+        H_dc   = H_deficit_carry_init.copy()     # per-sub-catchment carried deficit
 
-        # Local copy of f_to_discharge — frozen-ground overrides res[0] temporarily
+        # Local copy of f_to_discharge — frozen-ground overrides the top
+        # reservoir of a sub-catchment temporarily.
         f_dis = f_dis_in.copy()
 
-        # Per-reservoir cascade working arrays
+        # Per-reservoir cascade working arrays (flat across all sub-catchments)
         H_to_next = np.zeros(n_res)
         H_deficit_res = np.zeros(n_res)
         H_tile = H_tile_init.copy()
@@ -105,245 +117,272 @@ if _numba_available:
                 skip = math.isnan(T_t)
 
             if skip:
-                Q_out[step]    = np.nan
-                SWE_out[step]  = H_snow_cur
+                Q_out[step] = np.nan
+                swe_tot = 0.0
                 H_sub_total = 0.0
+                for sc in range(n_sub):
+                    area = sc_area_fractions[sc]
+                    swe_tot += area * H_snow[sc]
+                    for r in range(sc_start_idx[sc], sc_end_idx[sc]):
+                        H_sub_total += area * (H_res[r] + H_tile[r])
                 for r in range(n_res):
-                    H_sub_total += H_res[r] + H_tile[r]
                     H_res_out[step, r] = H_res[r]
+                SWE_out[step]   = swe_tot
                 H_sub_out[step] = H_sub_total
                 continue
 
-            # ── Snowpack ──────────────────────────────────────────────────
-            sp_infiltrated = 0.0
-            sp_deficit     = 0.0
-            excess_dd      = 0.0
+            qi_basin    = 0.0
+            swe_tot     = 0.0
+            H_sub_total = 0.0
 
-            if has_snowpack:
-                if use_et_reservoir_draw:
-                    sp_recharge = P_t + H_deficit_carry
-                else:
-                    sp_recharge = P_t - ET_t + H_deficit_carry
+            for sc in range(n_sub):
+                r_start = sc_start_idx[sc]
+                r_end   = sc_end_idx[sc]
+                area    = sc_area_fractions[sc]
+                H_snow_cur = H_snow[sc]
+                fgi_cur    = fgi[sc]
+                H_dc_sc    = H_dc[sc]
 
-                # Snowpack.recharge(sp_recharge)
-                if sp_recharge >= 0.0:
-                    if T_t <= 0.0:
-                        H_snow_cur += sp_recharge
+                # ── Snowpack ──────────────────────────────────────────────
+                sp_infiltrated = 0.0
+                sp_deficit     = 0.0
+                excess_dd      = 0.0
+
+                if has_snowpack:
+                    if use_et_reservoir_draw:
+                        sp_recharge = P_t + H_dc_sc
+                    else:
+                        sp_recharge = P_t - ET_t + H_dc_sc
+
+                    # Snowpack.recharge(sp_recharge)
+                    if sp_recharge >= 0.0:
+                        if T_t <= 0.0:
+                            H_snow_cur += sp_recharge
+                            # sp_infiltrated stays 0
+                        else:
+                            sp_infiltrated = sp_recharge
+                    else:
+                        # Sublimation; deficit if snow insufficient
+                        if H_snow_cur > -sp_recharge:
+                            H_snow_cur += sp_recharge
+                        else:
+                            sp_deficit = sp_recharge + H_snow_cur
+                            H_snow_cur = 0.0
                         # sp_infiltrated stays 0
-                    else:
-                        sp_infiltrated = sp_recharge
-                else:
-                    # Sublimation; deficit if snow insufficient
-                    if H_snow_cur > -sp_recharge:
-                        H_snow_cur += sp_recharge
-                    else:
-                        sp_deficit = sp_recharge + H_snow_cur
-                        H_snow_cur = 0.0
-                    # sp_infiltrated stays 0
 
-                # Snowpack.melt(dt, P)
-                if T_t > 0.0:
-                    pdd     = melt_factor * T_t * dt
-                    ros_P   = P_t if use_rain_on_snow else 0.0
-                    ros     = _CP_LF * T_t * ros_P
-                    total_m = pdd + ros
-                    if total_m <= H_snow_cur:
-                        actual_melt = total_m
-                    else:
-                        actual_melt = H_snow_cur
-                        if melt_factor > 0.0:
-                            excess_dd = (total_m - actual_melt) / melt_factor
-                    sp_infiltrated += actual_melt
-                    H_snow_cur     -= actual_melt
-
-                # Temporarily store snowpack deficit as carry for res[0] recharge
-                H_deficit_carry_for_res0 = sp_deficit
-            else:
-                H_deficit_carry_for_res0 = H_deficit_carry
-
-            # ── FGI update ────────────────────────────────────────────────
-            f0_frozen = f_dis[0]   # save calibrated value before possible override
-
-            if use_fgi and not math.isinf(fdd_threshold):
-                T_eff = T_t * math.exp(-snow_insulation_k * H_snow_cur)
-
-                if has_trange:
-                    T_max_t = T_max_arr[step]
-                    T_min_t = T_min_arr[step]
-                    DTR = T_max_t - T_min_t
-                    # NaN comparisons evaluate False → A_t = 1.0 when data absent
-                    if DTR > 0.0 and T_max_t > 0.0:
-                        f_above = T_max_t / DTR
-                        if f_above > 1.0:
-                            f_above = 1.0
-                        A_t = 1.0 - (1.0 - fgi_decay_coeff) * f_above
-                    else:
-                        A_t = 1.0
-                else:
-                    A_t = fgi_decay_coeff
-
-                new_fgi = A_t * fgi_cur - T_eff - excess_dd
-                if new_fgi < 0.0 or math.isnan(new_fgi):
-                    new_fgi = 0.0
-                fgi_cur = new_fgi
-                if fgi_cur > fdd_threshold:
-                    f_dis[0] = 1.0   # frozen ground: all drainage → direct runoff
-
-            # ── Reservoir cascade ─────────────────────────────────────────
-            qi = 0.0
-
-            for r in range(n_res):
-                # --- Recharge ---
-                H_res_excess  = 0.0
-                H_res_deficit = 0.0
-
-                if r == 0:
-                    if has_snowpack:
-                        _rech = sp_infiltrated + H_deficit_carry_for_res0
-                    else:
-                        if use_et_reservoir_draw:
-                            _rech = P_t + H_deficit_carry_for_res0
+                    # Snowpack.melt(dt, P)
+                    if T_t > 0.0:
+                        pdd     = melt_factor * T_t * dt
+                        ros_P   = P_t if use_rain_on_snow else 0.0
+                        ros     = _CP_LF * T_t * ros_P
+                        total_m = pdd + ros
+                        if total_m <= H_snow_cur:
+                            actual_melt = total_m
                         else:
-                            _rech = P_t - ET_t + H_deficit_carry_for_res0
+                            actual_melt = H_snow_cur
+                            if melt_factor > 0.0:
+                                excess_dd = (total_m - actual_melt) / melt_factor
+                        sp_infiltrated += actual_melt
+                        H_snow_cur     -= actual_melt
 
-                    if use_direct_runoff and _rech > 0.0:
-                        q_direct = _rech * direct_runoff_fraction
-                        qi      += q_direct
-                        _rech   -= q_direct
+                    # Temporarily store snowpack deficit as carry for res recharge
+                    H_deficit_carry_for_res0 = sp_deficit
                 else:
-                    _rech = H_to_next[r - 1] + H_deficit_res[r - 1]
+                    H_deficit_carry_for_res0 = H_dc_sc
 
-                new_H = H_res[r] + _rech
-                if new_H < 0.0:
-                    H_res_deficit = new_H   # negative
-                    H_res[r] = 0.0
-                elif (not math.isinf(Hmax_arr[r])) and new_H > Hmax_arr[r]:
-                    H_res_excess = new_H - Hmax_arr[r]
-                    H_res[r]     = Hmax_arr[r]
-                else:
-                    H_res[r] = new_H
+                # ── FGI update ────────────────────────────────────────────
+                # save calibrated value before possible override
+                f0_frozen = f_dis[r_start]
 
-                H_deficit_res[r] = H_res_deficit
+                if use_fgi and not math.isinf(fdd_threshold):
+                    T_eff = T_t * math.exp(-snow_insulation_k * H_snow_cur)
 
-                # --- Discharge ---
-                b_r  = b_arr[r]
-                H0_r = H_res[r]
-
-                # Threshold junction: recession only above H_threshold
-                if junction_arr[r] == 2:
-                    H_eff = H0_r - H_threshold_arr[r]
-                    if H_eff < 0.0:
-                        H_eff = 0.0
-                else:
-                    H_eff = H0_r
-
-                if b_r == 1.0 or H_eff <= 0.0:
-                    dH = H_eff * (1.0 - math.exp(-dt / tau_arr[r]))
-                else:
-                    # Exact integration: H(t+dt) = [H^(1-b) + (b-1)dt/tau_eff]^(1/(1-b))
-                    tau_eff = tau_arr[r] * (H_ref_arr[r] ** (b_r - 1.0))
-                    arg     = H_eff ** (1.0 - b_r) + (b_r - 1.0) * dt / tau_eff
-                    H_new_r = arg ** (1.0 / (1.0 - b_r)) if arg > 0.0 else 0.0
-                    dH      = H_eff - H_new_r
-                    if dH < 0.0:
-                        dH = 0.0
-
-                # Partition dH: leakance applies to non-bottom reservoirs only
-                is_bottom = (r == n_res - 1)
-                if junction_arr[r] == 1 and not is_bottom:
-                    # Q_leak = min(dH, max(0, H_this - H_next) / R)
-                    diff    = H0_r - H_res[r + 1]   # H_res[r+1] pre-recharge/discharge
-                    if diff < 0.0:
-                        diff = 0.0
-                    Q_leak  = diff / leakance_R_arr[r]
-                    if Q_leak > dH:
-                        Q_leak = dH
-                    H_to_next[r] = Q_leak
-                    H_exfiltrated    = dH - Q_leak
-                else:
-                    H_exfiltrated    = dH * f_dis[r]
-                    H_to_next[r] = dH * (1.0 - f_dis[r])
-
-                H_discharge = H_res_excess + H_exfiltrated
-                H_res[r]   -= dH
-                qi         += H_discharge
-
-                # Tile drain: intercept f_tile fraction of H_to_next,
-                # route through a linear (b=1) sub-reservoir, discharge to stream.
-                if f_tile_arr[r] > 0.0:
-                    tile_in       = f_tile_arr[r] * H_to_next[r]
-                    H_to_next[r] -= tile_in
-                    H_tile[r]    += tile_in
-                    tile_dH       = H_tile[r] * (1.0 - math.exp(-dt / tau_tile_arr[r]))
-                    H_tile[r]    -= tile_dH
-                    qi           += tile_dH
-
-                # Multipath drainage: a parallel fast path from this reservoir
-                # direct to stream, active when storage exceeds the threshold.
-                # Applied after primary recession via operator splitting
-                # (first-order accurate; acceptable at daily dt). Bypasses the
-                # junction/f_to_discharge partition.
-                if multipath_tau_arr[r] > 0.0:
-                    H_above_mp = H_res[r] - multipath_thr_arr[r]
-                    if H_above_mp > 0.0:
-                        dH_mp        = H_above_mp * (
-                            1.0 - math.exp(-dt / multipath_tau_arr[r]))
-                        H_res[r]    -= dH_mp
-                        qi          += dH_mp
-
-            # Restore calibrated f_to_discharge[0] (undo frozen-ground override)
-            f_dis[0] = f0_frozen
-
-            # Carry deficit from bottom reservoir to next timestep
-            H_deficit_carry = H_deficit_res[n_res - 1]
-
-            # ── ET draw from reservoirs ───────────────────────────────────
-            if use_et_reservoir_draw:
-                demand0 = et_alpha * ET_t
-                avail0  = H_res[0] if H_res[0] > 0.0 else 0.0
-                actual0 = demand0 if demand0 <= avail0 else avail0
-                H_res[0] -= actual0
-                # Condensation (negative ET) that overtops the cap runs off.
-                if H_res[0] > Hmax_arr[0]:
-                    qi       += H_res[0] - Hmax_arr[0]
-                    H_res[0]  = Hmax_arr[0]
-
-                if n_res >= 2:
-                    demand1 = (1.0 - et_alpha) * ET_t
-                    if wp_soil > 0.0:
-                        if wp_soil_sigma > 0.0:
-                            # Gaussian CDF: demand scaled; draw from full H
-                            f_avail = 0.5 * (1.0 + math.erf(
-                                (H_res[1] - wp_soil)
-                                / (wp_soil_sigma * math.sqrt(2.0))))
-                            demand1 = demand1 * f_avail
-                            avail1  = H_res[1] if H_res[1] > 0.0 else 0.0
+                    if has_trange:
+                        T_max_t = T_max_arr[step]
+                        T_min_t = T_min_arr[step]
+                        DTR = T_max_t - T_min_t
+                        # NaN comparisons → False → A_t = 1.0 when data absent
+                        if DTR > 0.0 and T_max_t > 0.0:
+                            f_above = T_max_t / DTR
+                            if f_above > 1.0:
+                                f_above = 1.0
+                            A_t = 1.0 - (1.0 - fgi_decay_coeff) * f_above
                         else:
-                            # Hard threshold: no draw below wp_soil
-                            if H_res[1] <= wp_soil:
-                                demand1 = 0.0
-                                avail1  = 0.0
+                            A_t = 1.0
+                    else:
+                        A_t = fgi_decay_coeff
+
+                    new_fgi = A_t * fgi_cur - T_eff - excess_dd
+                    if new_fgi < 0.0 or math.isnan(new_fgi):
+                        new_fgi = 0.0
+                    fgi_cur = new_fgi
+                    if fgi_cur > fdd_threshold:
+                        f_dis[r_start] = 1.0   # frozen ground: all → direct runoff
+
+                # ── Reservoir cascade ─────────────────────────────────────
+                qi = 0.0
+
+                for r in range(r_start, r_end):
+                    # --- Recharge ---
+                    H_res_excess  = 0.0
+                    H_res_deficit = 0.0
+
+                    if r == r_start:
+                        if has_snowpack:
+                            _rech = sp_infiltrated + H_deficit_carry_for_res0
+                        else:
+                            if use_et_reservoir_draw:
+                                _rech = P_t + H_deficit_carry_for_res0
                             else:
-                                avail1 = H_res[1] - wp_soil
-                    else:
-                        avail1 = H_res[1] if H_res[1] > 0.0 else 0.0
-                    actual1 = demand1 if demand1 <= avail1 else avail1
-                    H_res[1] -= actual1
-                    if H_res[1] > Hmax_arr[1]:
-                        qi       += H_res[1] - Hmax_arr[1]
-                        H_res[1]  = Hmax_arr[1]
+                                _rech = P_t - ET_t + H_deficit_carry_for_res0
 
-            # ── Record outputs ────────────────────────────────────────────
-            Q_out[step]   = qi
-            SWE_out[step] = H_snow_cur
-            H_sub_total   = 0.0
+                        if use_direct_runoff and _rech > 0.0:
+                            q_direct = _rech * direct_runoff_fraction
+                            qi      += q_direct
+                            _rech   -= q_direct
+                    else:
+                        _rech = H_to_next[r - 1] + H_deficit_res[r - 1]
+
+                    new_H = H_res[r] + _rech
+                    if new_H < 0.0:
+                        H_res_deficit = new_H   # negative
+                        H_res[r] = 0.0
+                    elif (not math.isinf(Hmax_arr[r])) and new_H > Hmax_arr[r]:
+                        H_res_excess = new_H - Hmax_arr[r]
+                        H_res[r]     = Hmax_arr[r]
+                    else:
+                        H_res[r] = new_H
+
+                    H_deficit_res[r] = H_res_deficit
+
+                    # --- Discharge ---
+                    b_r  = b_arr[r]
+                    H0_r = H_res[r]
+
+                    # Threshold junction: recession only above H_threshold
+                    if junction_arr[r] == 2:
+                        H_eff = H0_r - H_threshold_arr[r]
+                        if H_eff < 0.0:
+                            H_eff = 0.0
+                    else:
+                        H_eff = H0_r
+
+                    if b_r == 1.0 or H_eff <= 0.0:
+                        dH = H_eff * (1.0 - math.exp(-dt / tau_arr[r]))
+                    else:
+                        # Exact integration: H(t+dt) = [H^(1-b) + (b-1)dt/tau_eff]^(1/(1-b))
+                        tau_eff = tau_arr[r] * (H_ref_arr[r] ** (b_r - 1.0))
+                        arg     = H_eff ** (1.0 - b_r) + (b_r - 1.0) * dt / tau_eff
+                        H_new_r = arg ** (1.0 / (1.0 - b_r)) if arg > 0.0 else 0.0
+                        dH      = H_eff - H_new_r
+                        if dH < 0.0:
+                            dH = 0.0
+
+                    # Partition dH: leakance applies to non-bottom reservoirs
+                    is_bottom = (r == r_end - 1)
+                    if junction_arr[r] == 1 and not is_bottom:
+                        # Q_leak = min(dH, max(0, H_this - H_next) / R)
+                        diff    = H0_r - H_res[r + 1]   # H_res[r+1] pre-recharge/discharge
+                        if diff < 0.0:
+                            diff = 0.0
+                        Q_leak  = diff / leakance_R_arr[r]
+                        if Q_leak > dH:
+                            Q_leak = dH
+                        H_to_next[r] = Q_leak
+                        H_exfiltrated    = dH - Q_leak
+                    else:
+                        H_exfiltrated    = dH * f_dis[r]
+                        H_to_next[r] = dH * (1.0 - f_dis[r])
+
+                    H_discharge = H_res_excess + H_exfiltrated
+                    H_res[r]   -= dH
+                    qi         += H_discharge
+
+                    # Tile drain: intercept f_tile fraction of H_to_next,
+                    # route through a linear (b=1) sub-reservoir, to stream.
+                    if f_tile_arr[r] > 0.0:
+                        tile_in       = f_tile_arr[r] * H_to_next[r]
+                        H_to_next[r] -= tile_in
+                        H_tile[r]    += tile_in
+                        tile_dH       = H_tile[r] * (1.0 - math.exp(-dt / tau_tile_arr[r]))
+                        H_tile[r]    -= tile_dH
+                        qi           += tile_dH
+
+                    # Multipath drainage: a parallel fast path from this
+                    # reservoir direct to stream, active when storage exceeds
+                    # the threshold. Applied after primary recession via
+                    # operator splitting (first-order accurate; acceptable at
+                    # daily dt). Bypasses the junction/f_to_discharge partition.
+                    if multipath_tau_arr[r] > 0.0:
+                        H_above_mp = H_res[r] - multipath_thr_arr[r]
+                        if H_above_mp > 0.0:
+                            dH_mp        = H_above_mp * (
+                                1.0 - math.exp(-dt / multipath_tau_arr[r]))
+                            H_res[r]    -= dH_mp
+                            qi          += dH_mp
+
+                # Restore calibrated f_to_discharge (undo frozen-ground override)
+                f_dis[r_start] = f0_frozen
+
+                # Carry deficit from this sub-catchment's bottom reservoir
+                H_dc_sc = H_deficit_res[r_end - 1]
+
+                # ── ET draw from reservoirs ───────────────────────────────
+                if use_et_reservoir_draw:
+                    demand0 = et_alpha * ET_t
+                    avail0  = H_res[r_start] if H_res[r_start] > 0.0 else 0.0
+                    actual0 = demand0 if demand0 <= avail0 else avail0
+                    H_res[r_start] -= actual0
+                    # Condensation (negative ET) overtopping the cap runs off.
+                    if H_res[r_start] > Hmax_arr[r_start]:
+                        qi             += H_res[r_start] - Hmax_arr[r_start]
+                        H_res[r_start]  = Hmax_arr[r_start]
+
+                    if (r_end - r_start) >= 2:
+                        r1 = r_start + 1
+                        demand1 = (1.0 - et_alpha) * ET_t
+                        if wp_soil > 0.0:
+                            if wp_soil_sigma > 0.0:
+                                # Gaussian CDF: demand scaled; draw from full H
+                                f_avail = 0.5 * (1.0 + math.erf(
+                                    (H_res[r1] - wp_soil)
+                                    / (wp_soil_sigma * math.sqrt(2.0))))
+                                demand1 = demand1 * f_avail
+                                avail1  = H_res[r1] if H_res[r1] > 0.0 else 0.0
+                            else:
+                                # Hard threshold: no draw below wp_soil
+                                if H_res[r1] <= wp_soil:
+                                    demand1 = 0.0
+                                    avail1  = 0.0
+                                else:
+                                    avail1 = H_res[r1] - wp_soil
+                        else:
+                            avail1 = H_res[r1] if H_res[r1] > 0.0 else 0.0
+                        actual1 = demand1 if demand1 <= avail1 else avail1
+                        H_res[r1] -= actual1
+                        if H_res[r1] > Hmax_arr[r1]:
+                            qi        += H_res[r1] - Hmax_arr[r1]
+                            H_res[r1]  = Hmax_arr[r1]
+
+                # Write back this sub-catchment's state and aggregate to basin
+                H_snow[sc] = H_snow_cur
+                fgi[sc]    = fgi_cur
+                H_dc[sc]   = H_dc_sc
+
+                qi_basin    += area * qi
+                swe_tot     += area * H_snow_cur
+                for r in range(r_start, r_end):
+                    H_sub_total += area * (H_res[r] + H_tile[r])
+
+            # ── Record basin outputs ──────────────────────────────────────
+            Q_out[step]   = qi_basin
+            SWE_out[step] = swe_tot
             for r in range(n_res):
-                H_sub_total += H_res[r] + H_tile[r]
                 H_res_out[step, r] = H_res[r]
             H_sub_out[step] = H_sub_total
 
         return (Q_out, SWE_out, H_sub_out, H_res_out, H_res, H_tile,
-                H_snow_cur, fgi_cur, H_deficit_carry)
+                H_snow, fgi, H_dc)
 
 
 class Reservoir(object):
@@ -2172,10 +2211,14 @@ class Buckets(object):
         followed by a scored run on the decade itself).
         """
         self._timestep_i = self.hydrodata.index[0]
-        self._run_initial_storage = (
-            sum(res.Hwater for res in self.reservoirs)
-            + (self.snowpack.Hwater if self.has_snowpack else 0.0)
-        )
+        # Area-weighted basin storage at the start of this run (reservoir water
+        # plus snowpack; tiles start empty), for check_mass_balance().
+        self._run_initial_storage = sum(
+            sc.area_fraction * (
+                sum(r.Hwater for r in sc.reservoirs)
+                + (sc.snowpack.Hwater
+                   if (self.has_snowpack and sc.snowpack is not None) else 0.0))
+            for sc in self.sub_catchments)
         if start is not None or end is not None:
             date_mask = pd.Series(True, index=self.hydrodata.index)
             if start is not None:
@@ -2215,16 +2258,38 @@ class Buckets(object):
                      if self._has_trange
                      else np.full(len(_idx), np.nan))
 
+            # Flatten the sub-catchments into reservoir-index ranges (matching
+            # the order of self.reservoirs) plus their area weights, and gather
+            # the per-sub-catchment snowpack / FGI / carried-deficit state.
+            _sc_start = np.empty(self.n_sub_catchments, dtype=np.int64)
+            _sc_end   = np.empty(self.n_sub_catchments, dtype=np.int64)
+            _sc_area  = np.empty(self.n_sub_catchments, dtype=np.float64)
+            _off = 0
+            for _k, _sc in enumerate(self.sub_catchments):
+                _sc_start[_k] = _off
+                _off         += len(_sc.reservoirs)
+                _sc_end[_k]   = _off
+                _sc_area[_k]  = _sc.area_fraction
+            _snow_init = np.array(
+                [sc.snowpack.Hwater
+                 if (self.has_snowpack and sc.snowpack is not None) else 0.0
+                 for sc in self.sub_catchments], dtype=np.float64)
+            _fgi_init = np.array([sc.fgi for sc in self.sub_catchments],
+                                 dtype=np.float64)
+            _dc_init  = np.array([sc.H_deficit_carry
+                                  for sc in self.sub_catchments], dtype=np.float64)
+
             _jmap = {'fraction': 0, 'leakance': 1, 'threshold': 2}
             (_Q, _SWE, _Hsub, _Hres_out, _finalH, _finalHTile, _finalSnow,
              _finalFgi, _finalDC) = _jit_run(
                 _hd['Precipitation [mm/day]'].to_numpy(dtype=np.float64),
                 _hd['ET for model [mm/day]'].to_numpy(dtype=np.float64),
                 _T, _Tmin, _Tmax,
+                _sc_start, _sc_end, _sc_area,
                 np.array([r.Hwater          for r in self.reservoirs], dtype=np.float64),
-                self.snowpack.Hwater if self.has_snowpack else 0.0,
-                self._fgi,
-                self.H_deficit_carry,
+                _snow_init,
+                _fgi_init,
+                _dc_init,
                 np.array([r.recession_coeff      for r in self.reservoirs], dtype=np.float64),
                 np.array([r.recession_exponent  for r in self.reservoirs], dtype=np.float64),
                 np.array([r.recession_H_ref     for r in self.reservoirs], dtype=np.float64),
@@ -2271,14 +2336,13 @@ class Buckets(object):
             for _i, _r in enumerate(self.reservoirs):
                 if _r.tile_res is not None:
                     _r.tile_res.Hwater = float(_finalHTile[_i])
-            # The JIT path runs a single sub-catchment; write its final state
-            # back to the first (only) sub-catchment. (Multi-sub-catchment JIT
-            # support is added in a following commit.)
-            _sc0 = self.sub_catchments[0]
-            if self.has_snowpack:
-                _sc0.snowpack.Hwater = float(_finalSnow)
-            _sc0.fgi             = float(_finalFgi)
-            _sc0.H_deficit_carry = float(_finalDC)
+            # Write each sub-catchment's final snowpack / FGI / carried-deficit
+            # state back from the per-sub-catchment result arrays.
+            for _k, _sc in enumerate(self.sub_catchments):
+                if self.has_snowpack and _sc.snowpack is not None:
+                    _sc.snowpack.Hwater = float(_finalSnow[_k])
+                _sc.fgi             = float(_finalFgi[_k])
+                _sc.H_deficit_carry = float(_finalDC[_k])
 
         elif _run_idx is not None:
             for i in _run_idx:

--- a/mnished/mnished.py
+++ b/mnished/mnished.py
@@ -1002,6 +1002,37 @@ class Buckets(object):
         self.fdd_threshold = np.inf  # [°C·day]
         self._fgi          = 0.0    # current frozen ground index [°C·day]
 
+    @property
+    def reservoirs(self):
+        """
+        Flat list of every reservoir across all sub-catchments, ordered by
+        sub-catchment and then shallowest-to-deepest within each.
+
+        Backward-compatible view: for the common single-sub-catchment case
+        this is exactly the reservoir cascade as before. Reservoirs may be
+        mutated through this list (it returns the live objects), but the list
+        itself is rebuilt on each access, so assign to ``sub_catchments`` to
+        change the structure.
+        """
+        return [r for sc in self.sub_catchments for r in sc.reservoirs]
+
+    @reservoirs.setter
+    def reservoirs(self, value):
+        # Backward-compatible assignment for programmatic construction:
+        # ``buckets.reservoirs = [...]`` replaces the structure with a single
+        # sub-catchment holding the given cascade (area_fraction = 1.0). Any
+        # existing snowpack reference is preserved. To build multiple parallel
+        # sub-catchments, assign to ``sub_catchments`` directly.
+        snowpack = (self.sub_catchments[0].snowpack
+                    if getattr(self, 'sub_catchments', None) else None)
+        self.sub_catchments = [SubCatchment('basin', 1.0, list(value),
+                                            snowpack=snowpack)]
+
+    @property
+    def n_sub_catchments(self):
+        """Number of parallel sub-catchments (>= 1)."""
+        return len(self.sub_catchments)
+
     def _compute_Chang_I(self, T_monthly_normals):
         """
         Compute the Thornthwaite thermal index I from long-term monthly normal
@@ -1154,7 +1185,7 @@ class Buckets(object):
                                                     [None]  * self.n_reservoirs)
         _mp_timescale     = self.cfg['reservoirs'].get('multipath_timescales__days',
                                                     [None]  * self.n_reservoirs)
-        self.reservoirs = [
+        _basin_reservoirs = [
             Reservoir(
                 recession_coeff = self.cfg['reservoirs']['recession_coefficients'][i],
                 f_to_discharge = self.cfg['reservoirs']['exfiltration_fractions'][i],
@@ -1171,6 +1202,11 @@ class Buckets(object):
                 multipath_timescale = _mp_timescale[i],
             )
             for i in range(self.n_reservoirs)]
+        # The legacy single-cascade configuration is one sub-catchment covering
+        # the whole basin (area_fraction = 1.0); self.reservoirs (a property)
+        # then exposes the same flat cascade as before. Multi-sub-catchment
+        # YAML parsing is added in a following commit.
+        self.sub_catchments = [SubCatchment('basin', 1.0, _basin_reservoirs)]
         for i, b_exp in enumerate(_recession_exp):
             self.reservoirs[i].recession_exponent = float(b_exp)
 
@@ -1254,6 +1290,10 @@ class Buckets(object):
         if self.has_snowpack:
             # Instantiate snowpack
             self.snowpack = Snowpack(self.melt_factor)  # allow changes to melt factor later
+            # Mirror onto the sub-catchment(s); the time loops still read the
+            # basin-level self.snowpack until per-sub-catchment state is wired in.
+            for sc in self.sub_catchments:
+                sc.snowpack = self.snowpack
         elif 'Mean Temperature [C]' in self.hydrodata.columns and not self.use_snowpack:
             pass  # snowpack deliberately disabled via modules config
         else:

--- a/mnished/mnished.py
+++ b/mnished/mnished.py
@@ -891,6 +891,72 @@ class Snowpack(object):
         return excess_dd
 
 
+class SubCatchment(object):
+    """
+    A parallel hydraulic compartment of the basin with its own reservoir
+    cascade and per-compartment state.
+
+    Sub-catchments represent spatially distinct zones (e.g. till uplands vs.
+    lake-clay lowlands) that drain to the same river channel *in parallel*
+    rather than in a vertical cascade. Each sub-catchment is internally an
+    ordinary serial reservoir cascade; basin discharge is the area-weighted
+    mean of the sub-catchments' per-unit-area discharges. A model with a
+    single sub-catchment of ``area_fraction = 1.0`` reproduces the original
+    (non-partitioned) MNiShed behaviour exactly.
+
+    State that evolves independently per zone — snowpack, frozen-ground index,
+    and the carried recharge deficit — lives on the sub-catchment so that
+    per-sub-catchment forcing can be added later without changing the public
+    API. In this version the forcing is basin-shared, so these states evolve
+    identically across sub-catchments.
+
+    Parameters
+    ----------
+    name : str
+        Label for the sub-catchment. Must be unique within a basin.
+    area_fraction : float
+        Fraction of the basin area drained by this sub-catchment, in [0, 1].
+        The fractions across all sub-catchments must sum to 1.
+    reservoirs : list of Reservoir
+        The vertical reservoir cascade for this sub-catchment, ordered
+        shallowest (index 0) to deepest. Must contain at least one reservoir.
+    snowpack : Snowpack or None, optional
+        Snowpack state for this sub-catchment. None when the basin has no
+        snowpack module enabled. Default None.
+    fgi_init : float, optional
+        Initial frozen-ground index [°C·day] for this sub-catchment.
+        Default 0.0.
+    H_deficit_carry_init : float, optional
+        Initial recharge deficit [mm] carried into the first time step.
+        Default 0.0.
+    forcing : dict or None, optional
+        Per-sub-catchment forcing specification. Reserved for a future
+        release; supplying it raises NotImplementedError, because the current
+        implementation shares basin-level forcing across all sub-catchments.
+        Default None.
+    """
+
+    def __init__(self, name, area_fraction, reservoirs, *,
+                 snowpack=None, fgi_init=0.0, H_deficit_carry_init=0.0,
+                 forcing=None):
+        if forcing is not None:
+            raise NotImplementedError(
+                "Per-sub-catchment forcing is not yet supported; basin-level "
+                "forcing is shared across all sub-catchments. Remove the "
+                f"'forcing' block from sub-catchment '{name}'.")
+        if len(reservoirs) < 1:
+            raise ValueError(
+                f"Sub-catchment '{name}' has no reservoirs; each "
+                "sub-catchment must have at least one reservoir.")
+        self.name             = name
+        self.area_fraction    = area_fraction
+        self.reservoirs       = reservoirs
+        self.snowpack         = snowpack
+        self.fgi              = fgi_init
+        self.H_deficit_carry  = H_deficit_carry_init
+        self.forcing          = forcing
+
+
 class Buckets(object):
     """
     Incorporates a list of reservoirs into a linear hierarchy that sends water

--- a/tests/test_sub_catchments.py
+++ b/tests/test_sub_catchments.py
@@ -344,6 +344,55 @@ def test_run_and_score_sub_catchments(tmp_path):
     assert [r.recession_coeff for r in b.sub_catchments[1].reservoirs] == [1200]
 
 
+def test_capture_states_flat_for_single_sub_catchment(tmp_path):
+    """A single sub-catchment captures the legacy flat/scalar state dict."""
+    import mnished
+    from mnished.calibration import _capture_states
+    cfg = _legacy_cfg([14, 500], [0.3, 1.0], [float('inf'), float('inf')], [5, 300])
+    b = mnished.Buckets()
+    b.initialize(_write(tmp_path, cfg))
+    state = _capture_states(b)
+    assert 'sub_catchments' not in state
+    assert set(state) == {'reservoirs', 'snowpack', 'fgi', 'H_deficit_carry'}
+    assert len(state['reservoirs']) == 2
+
+
+def test_decadal_chaining_round_trips_k_gt_1(tmp_path):
+    """Chaining two windows via captured/restored per-sub-catchment state
+    reproduces a single continuous run."""
+    import mnished
+    from mnished.calibration import _capture_states, _restore_initial_states
+    cfg_path = _write(tmp_path, _two_sc_cfg())
+
+    b_cont = mnished.Buckets()
+    b_cont.initialize(cfg_path)
+    b_cont.run()
+    dates = b_cont.hydrodata['Date']
+    mid = dates.iloc[len(dates) // 2]
+    after = dates.iloc[len(dates) // 2 + 1]
+    q_cont = b_cont.hydrodata[Q_COL].astype(float).to_numpy()
+
+    # Run to mid, capture per-sub-catchment state, restore into a fresh model.
+    b_a = mnished.Buckets()
+    b_a.initialize(cfg_path)
+    b_a.run(end=mid)
+    state = _capture_states(b_a)
+    assert 'sub_catchments' in state and len(state['sub_catchments']) == 2
+    assert set(state['sub_catchments'][0]) == {
+        'reservoirs', 'snowpack', 'fgi', 'H_deficit_carry'}
+
+    b_b = mnished.Buckets()
+    b_b.initialize(cfg_path)
+    _restore_initial_states(b_b, state)
+    b_b.run(start=after)
+    # Rows before `after` are unrun (pd.NA); coerce to NaN.
+    q_chain = b_b.hydrodata[Q_COL].to_numpy(dtype='float64', na_value=np.nan)
+
+    mask = (dates >= after).to_numpy()
+    np.testing.assert_allclose(q_chain[mask], q_cont[mask],
+                               rtol=1e-9, atol=1e-9, equal_nan=True)
+
+
 def test_run_and_score_rejects_flat_and_structured(tmp_path):
     import mnished
     cfg = _two_sc_cfg()

--- a/tests/test_sub_catchments.py
+++ b/tests/test_sub_catchments.py
@@ -499,3 +499,34 @@ def test_jit_matches_pure_python_three_sub_catchments(tmp_path, monkeypatch):
     assert len(b_jit.reservoirs) == 6        # 1 + 2 + 3 across three zones
     np.testing.assert_allclose(q_jit, q_py, rtol=1e-7, atol=1e-9, equal_nan=True)
     np.testing.assert_allclose(s_jit, s_py, rtol=1e-7, atol=1e-9, equal_nan=True)
+
+
+# ---------------------------------------------------------------------------
+# 12. store_depths column naming
+# ---------------------------------------------------------------------------
+
+def test_store_depths_column_names(tmp_path):
+    """store_depths keeps the legacy column names for a single sub-catchment
+    and labels columns by sub-catchment name (and within-zone index) for
+    several."""
+    import mnished
+
+    # K=1: legacy names, unchanged.
+    legacy = _legacy_cfg([14, 500], [0.3, 1.0], [float('inf'), float('inf')],
+                         [5, 300])
+    b1 = mnished.Buckets()
+    b1.initialize(_write(tmp_path, legacy, "one.yml"))
+    b1.run(store_depths=True)
+    assert 'H_reservoir_0 (modeled) [mm]' in b1.hydrodata.columns
+    assert 'H_reservoir_1 (modeled) [mm]' in b1.hydrodata.columns
+
+    # K>1: columns labeled by sub-catchment name and within-zone index.
+    b2 = mnished.Buckets()
+    b2.initialize(_write(tmp_path, _two_sc_cfg(), "two.yml"))
+    b2.run(store_depths=True)
+    cols = b2.hydrodata.columns
+    assert 'H_till_reservoir_0 (modeled) [mm]' in cols
+    assert 'H_till_reservoir_1 (modeled) [mm]' in cols
+    assert 'H_clay_reservoir_0 (modeled) [mm]' in cols
+    # The ambiguous flat names must not appear when there are several zones.
+    assert 'H_reservoir_0 (modeled) [mm]' not in cols

--- a/tests/test_sub_catchments.py
+++ b/tests/test_sub_catchments.py
@@ -1,0 +1,356 @@
+"""
+Tests for parallel sub-catchments.
+
+A SubCatchment is a parallel hydraulic compartment of the basin with its own
+reservoir cascade; basin discharge is the area-weighted mean of the
+sub-catchments. A single sub-catchment of area_fraction 1.0 reproduces the
+original (non-partitioned) behaviour exactly.
+
+Forcing uses the Cannon River forward example (examples/cannon_forward/).
+"""
+
+import os
+
+import numpy as np
+import pytest
+import yaml
+
+EXAMPLE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "examples", "cannon_forward")
+)
+CANNON_CSV = os.path.join(EXAMPLE_DIR, "CannonTestInput.csv")
+
+Q_COL = "Specific Discharge (modeled) [mm/day]"
+S_COL = "Subsurface storage (modeled total) [mm]"
+
+
+def _base_cfg(spin_up_cycles=0):
+    """Cannon-forced config skeleton without a reservoir structure."""
+    return {
+        'timeseries': {'datafile': CANNON_CSV},
+        'catchment': {
+            'drainage_basin_area__km2': 3800,
+            'evapotranspiration_method': 'datafile',
+            'water_year_start_month': 10,
+        },
+        'general': {'spin_up_cycles': spin_up_cycles},
+        'snowmelt': {'PDD_melt_factor': 1.0, 'fgi_decay_coeff': 0.97,
+                     'snow_insulation_k': 0.0},
+        'modules': {'snowpack': True, 'frozen_ground': True,
+                    'rain_on_snow': True, 'direct_runoff': False},
+    }
+
+
+def _legacy_cfg(recession, exfil, hmax, h0):
+    cfg = _base_cfg()
+    cfg['reservoirs'] = {
+        'recession_coefficients': recession,
+        'exfiltration_fractions': exfil,
+        'maximum_effective_depths__mm': hmax,
+    }
+    cfg['initial_conditions'] = {
+        'water_reservoir_effective_depths__mm': h0,
+        'snowpack__mm_SWE': 0,
+    }
+    return cfg
+
+
+def _write(tmp_path, cfg, name="cfg.yml"):
+    p = tmp_path / name
+    p.write_text(yaml.safe_dump(cfg))
+    return str(p)
+
+
+def _run(cfg_path, cycles=3):
+    import mnished
+    b = mnished.Buckets()
+    b.initialize(cfg_path)
+    for _ in range(cycles):
+        b.run()
+    b.run()
+    return b
+
+
+# ---------------------------------------------------------------------------
+# 1. Legacy single-cascade configs are one sub-catchment of area 1.0
+# ---------------------------------------------------------------------------
+
+def test_legacy_yaml_is_single_sub_catchment(tmp_path):
+    cfg = _legacy_cfg([14, 40, 500], [0.19, 0.76, 1.0],
+                      [18.0, float('inf'), float('inf')], [15, 40, 500])
+    import mnished
+    b = mnished.Buckets()
+    b.initialize(_write(tmp_path, cfg))
+    assert b.n_sub_catchments == 1
+    assert b.sub_catchments[0].area_fraction == 1.0
+    assert len(b.reservoirs) == 3
+    assert b.sub_catchments[0].reservoirs is not None
+    assert len(b.sub_catchments[0].reservoirs) == 3
+
+
+# ---------------------------------------------------------------------------
+# 2. A two-sub-catchment config loads with the right structure
+# ---------------------------------------------------------------------------
+
+def _two_sc_cfg(area_a=0.55, area_b=0.45):
+    cfg = _base_cfg()
+    cfg['sub_catchments'] = [
+        {'name': 'till', 'area_fraction': area_a,
+         'reservoirs': {'recession_coefficients': [14, 500],
+                        'exfiltration_fractions': [0.3, 1.0],
+                        'maximum_effective_depths__mm': [20.0, float('inf')]},
+         'initial_conditions': {'water_reservoir_effective_depths__mm': [5, 300]}},
+        {'name': 'clay', 'area_fraction': area_b,
+         'reservoirs': {'recession_coefficients': [1500],
+                        'exfiltration_fractions': [1.0],
+                        'maximum_effective_depths__mm': [float('inf')]}},
+    ]
+    return cfg
+
+
+def test_two_sub_catchments_load(tmp_path):
+    import mnished
+    b = mnished.Buckets()
+    b.initialize(_write(tmp_path, _two_sc_cfg()))
+    assert b.n_sub_catchments == 2
+    assert [sc.name for sc in b.sub_catchments] == ['till', 'clay']
+    assert [sc.area_fraction for sc in b.sub_catchments] == [0.55, 0.45]
+    assert [len(sc.reservoirs) for sc in b.sub_catchments] == [2, 1]
+    assert len(b.reservoirs) == 3            # flattened across sub-catchments
+    # Per-sub-catchment initial depths; the second defaults to zero.
+    assert [r.Hwater for r in b.sub_catchments[0].reservoirs] == [5, 300]
+    assert [r.Hwater for r in b.sub_catchments[1].reservoirs] == [0.0]
+
+
+# ---------------------------------------------------------------------------
+# 3. Validation
+# ---------------------------------------------------------------------------
+
+def test_area_fractions_must_sum_to_one(tmp_path):
+    import mnished
+    cfg = _two_sc_cfg(area_a=0.55, area_b=0.55)
+    with pytest.raises(ValueError, match="sum to 1"):
+        mnished.Buckets().initialize(_write(tmp_path, cfg))
+
+
+def test_duplicate_names_raise(tmp_path):
+    import mnished
+    cfg = _two_sc_cfg()
+    cfg['sub_catchments'][1]['name'] = 'till'
+    with pytest.raises(ValueError, match="unique"):
+        mnished.Buckets().initialize(_write(tmp_path, cfg))
+
+
+def test_empty_reservoirs_raise(tmp_path):
+    import mnished
+    cfg = _two_sc_cfg()
+    cfg['sub_catchments'][1]['reservoirs'] = {
+        'recession_coefficients': [], 'exfiltration_fractions': [],
+        'maximum_effective_depths__mm': []}
+    with pytest.raises(ValueError, match="at least one reservoir"):
+        mnished.Buckets().initialize(_write(tmp_path, cfg))
+
+
+# ---------------------------------------------------------------------------
+# 4. Mass balance is conserved across sub-catchments
+# ---------------------------------------------------------------------------
+
+def test_mass_balance_conserved(tmp_path):
+    """A two-sub-catchment run conserves mass (excess ≈ 0 vs total flux)."""
+    b = _run(_write(tmp_path, _two_sc_cfg()))
+    excess = b.check_mass_balance()
+    total_P = b.hydrodata['Precipitation [mm/day]'].sum()
+    assert abs(excess) < 1e-6 * total_P
+
+
+# ---------------------------------------------------------------------------
+# 5. Two identical sub-catchments reproduce one cascade
+# ---------------------------------------------------------------------------
+
+def test_two_identical_sub_catchments_equal_one(tmp_path):
+    legacy = _legacy_cfg([14, 500], [0.3, 1.0], [20.0, float('inf')], [5, 300])
+    b_one = _run(_write(tmp_path, legacy, "one.yml"))
+    q_one = b_one.hydrodata[Q_COL].astype(float).to_numpy()
+
+    cfg = _base_cfg()
+
+    def _sc():
+        return {'reservoirs': {'recession_coefficients': [14, 500],
+                               'exfiltration_fractions': [0.3, 1.0],
+                               'maximum_effective_depths__mm': [20.0, float('inf')]},
+                'initial_conditions': {
+                    'water_reservoir_effective_depths__mm': [5, 300]}}
+    cfg['sub_catchments'] = [dict(name='a', area_fraction=0.6, **_sc()),
+                             dict(name='b', area_fraction=0.4, **_sc())]
+    b_two = _run(_write(tmp_path, cfg, "two.yml"))
+    q_two = b_two.hydrodata[Q_COL].astype(float).to_numpy()
+
+    np.testing.assert_allclose(q_two, q_one, rtol=1e-9, atol=1e-9, equal_nan=True)
+
+
+# ---------------------------------------------------------------------------
+# 6. Parallel sub-catchments differ from a serial cascade
+# ---------------------------------------------------------------------------
+
+def test_parallel_differs_from_serial(tmp_path):
+    """Two reservoirs run as parallel sub-catchments are not the same model as
+    the two reservoirs in a vertical cascade."""
+    serial = _legacy_cfg([14, 500], [0.3, 1.0], [float('inf'), float('inf')],
+                         [50, 50])
+    b_serial = _run(_write(tmp_path, serial, "serial.yml"))
+    q_serial = b_serial.hydrodata[Q_COL].astype(float).to_numpy()
+
+    cfg = _base_cfg()
+    cfg['sub_catchments'] = [
+        {'name': 'fast', 'area_fraction': 0.5,
+         'reservoirs': {'recession_coefficients': [14],
+                        'exfiltration_fractions': [1.0],
+                        'maximum_effective_depths__mm': [float('inf')]},
+         'initial_conditions': {'water_reservoir_effective_depths__mm': [50]}},
+        {'name': 'slow', 'area_fraction': 0.5,
+         'reservoirs': {'recession_coefficients': [500],
+                        'exfiltration_fractions': [1.0],
+                        'maximum_effective_depths__mm': [float('inf')]},
+         'initial_conditions': {'water_reservoir_effective_depths__mm': [50]}},
+    ]
+    b_parallel = _run(_write(tmp_path, cfg, "parallel.yml"))
+    q_parallel = b_parallel.hydrodata[Q_COL].astype(float).to_numpy()
+
+    assert np.nanmax(np.abs(q_serial - q_parallel)) > 1e-3
+
+
+# ---------------------------------------------------------------------------
+# 7. Multipath drainage works inside a sub-catchment
+# ---------------------------------------------------------------------------
+
+def test_multipath_in_sub_catchment(tmp_path):
+    """A sub-catchment with a multipath drain responds differently from one
+    without — the per-sub-catchment cascade honours multipath parameters."""
+    def cfg(multipath):
+        c = _base_cfg()
+        sc1 = {'name': 'a', 'area_fraction': 0.5,
+               'reservoirs': {'recession_coefficients': [200],
+                              'exfiltration_fractions': [1.0],
+                              'maximum_effective_depths__mm': [float('inf')]},
+               'initial_conditions': {'water_reservoir_effective_depths__mm': [100]}}
+        sc2 = {'name': 'b', 'area_fraction': 0.5,
+               'reservoirs': {'recession_coefficients': [200],
+                              'exfiltration_fractions': [1.0],
+                              'maximum_effective_depths__mm': [float('inf')]},
+               'initial_conditions': {'water_reservoir_effective_depths__mm': [100]}}
+        if multipath:
+            sc2['reservoirs']['multipath_thresholds__mm'] = [20.0]
+            sc2['reservoirs']['multipath_timescales__days'] = [3.0]
+        c['sub_catchments'] = [sc1, sc2]
+        return c
+
+    q_plain = _run(_write(tmp_path, cfg(False), "plain.yml")
+                   ).hydrodata[Q_COL].astype(float).to_numpy()
+    q_mp = _run(_write(tmp_path, cfg(True), "mp.yml")
+                ).hydrodata[Q_COL].astype(float).to_numpy()
+    assert np.nanmax(np.abs(q_plain - q_mp)) > 1e-3
+
+
+# ---------------------------------------------------------------------------
+# 8. Per-sub-catchment forcing is reserved but not yet implemented
+# ---------------------------------------------------------------------------
+
+def test_per_sub_catchment_forcing_not_implemented(tmp_path):
+    import mnished
+    cfg = _two_sc_cfg()
+    cfg['sub_catchments'][0]['forcing'] = {'datafile': 'till_forcing.csv'}
+    with pytest.raises(NotImplementedError):
+        mnished.Buckets().initialize(_write(tmp_path, cfg))
+
+
+# ---------------------------------------------------------------------------
+# 9. JIT and pure-Python agree for multiple sub-catchments
+# ---------------------------------------------------------------------------
+
+def test_jit_matches_pure_python_sub_catchments(tmp_path, monkeypatch):
+    """The Numba and pure-Python loops agree for two sub-catchments with
+    differing cascades and the advanced reservoir mechanics enabled."""
+    pytest.importorskip("numba", exc_type=ImportError)
+    import mnished
+    import mnished.mnished as _m
+
+    cfg = _base_cfg()
+    cfg['general']['et_alpha'] = 0.6
+    cfg['modules']['et_reservoir_draw'] = True
+    cfg['sub_catchments'] = [
+        {'name': 'till', 'area_fraction': 0.55,
+         'reservoirs': {
+             'recession_coefficients': [14, 500],
+             'exfiltration_fractions': [0.3, 1.0],
+             'maximum_effective_depths__mm': [20.0, float('inf')],
+             'recession_exponents': [2.0, 1.0],
+             'junction_types': ['threshold', 'fraction'],
+             'H_threshold__mm': [3.0, 0.0],
+             'tile_fractions': [0.3, 0.0],
+             'tile_residence_times__days': [3.0, None],
+             'multipath_thresholds__mm': [10.0, None],
+             'multipath_timescales__days': [5.0, None]},
+         'initial_conditions': {
+             'water_reservoir_effective_depths__mm': [5, 300],
+             'snowpack__mm_SWE': 2.0}},
+        {'name': 'clay', 'area_fraction': 0.45,
+         'reservoirs': {
+             'recession_coefficients': [40, 1500],
+             'exfiltration_fractions': [0.5, 1.0],
+             'maximum_effective_depths__mm': [float('inf'), float('inf')],
+             'junction_types': ['leakance', 'fraction'],
+             'leakance_R__days': [50.0, None]},
+         'initial_conditions': {
+             'water_reservoir_effective_depths__mm': [30, 400],
+             'snowpack__mm_SWE': 1.0}},
+    ]
+    cfg_path = _write(tmp_path, cfg, "advanced_sc.yml")
+
+    b_jit = mnished.Buckets()
+    b_jit.initialize(cfg_path)
+    b_jit.run()
+    q_jit = b_jit.hydrodata[Q_COL].astype(float).to_numpy()
+    s_jit = b_jit.hydrodata[S_COL].astype(float).to_numpy()
+
+    monkeypatch.setattr(_m, "_numba_available", False)
+    b_py = mnished.Buckets()
+    b_py.initialize(cfg_path)
+    b_py.run()
+    q_py = b_py.hydrodata[Q_COL].astype(float).to_numpy()
+    s_py = b_py.hydrodata[S_COL].astype(float).to_numpy()
+
+    np.testing.assert_allclose(q_jit, q_py, rtol=1e-7, atol=1e-9, equal_nan=True)
+    np.testing.assert_allclose(s_jit, s_py, rtol=1e-7, atol=1e-9, equal_nan=True)
+
+
+# ---------------------------------------------------------------------------
+# 10. run_and_score drives a multi-sub-catchment calibration
+# ---------------------------------------------------------------------------
+
+def test_run_and_score_sub_catchments(tmp_path):
+    import mnished
+    cfg = _two_sc_cfg()
+    cfg['general']['spin_up_cycles'] = 0
+    cfg_path = _write(tmp_path, cfg)
+
+    res = mnished.run_and_score(
+        cfg_path, spin_up_cycles=1, metric='KGE',
+        sub_catchments=[{'area_fraction': 0.6, 'recession_coeff': [20, 400]},
+                        {'area_fraction': 0.4, 'recession_coeff': [1200]}])
+    assert np.isfinite(res.score)
+    b = res.buckets
+    assert [sc.area_fraction for sc in b.sub_catchments] == [0.6, 0.4]
+    assert [r.recession_coeff for r in b.sub_catchments[0].reservoirs] == [20, 400]
+    assert [r.recession_coeff for r in b.sub_catchments[1].reservoirs] == [1200]
+
+
+def test_run_and_score_rejects_flat_and_structured(tmp_path):
+    import mnished
+    cfg = _two_sc_cfg()
+    cfg['general']['spin_up_cycles'] = 0
+    cfg_path = _write(tmp_path, cfg)
+    with pytest.raises(ValueError, match="inside each sub-catchment"):
+        mnished.run_and_score(
+            cfg_path, spin_up_cycles=0, recession_coeff=[1, 2, 3],
+            sub_catchments=[{'recession_coeff': [20, 400]},
+                            {'recession_coeff': [1200]}])

--- a/tests/test_sub_catchments.py
+++ b/tests/test_sub_catchments.py
@@ -403,3 +403,99 @@ def test_run_and_score_rejects_flat_and_structured(tmp_path):
             cfg_path, spin_up_cycles=0, recession_coeff=[1, 2, 3],
             sub_catchments=[{'recession_coeff': [20, 400]},
                             {'recession_coeff': [1200]}])
+
+
+# ---------------------------------------------------------------------------
+# 11. Generalization to three sub-catchments
+# ---------------------------------------------------------------------------
+
+def test_three_identical_sub_catchments_equal_one(tmp_path):
+    """Area weighting generalizes: three identical sub-catchments with a
+    three-way area split reproduce a single cascade, regardless of the split."""
+    legacy = _legacy_cfg([14, 500], [0.3, 1.0], [20.0, float('inf')], [5, 300])
+    q_one = _run(_write(tmp_path, legacy, "one.yml")
+                 ).hydrodata[Q_COL].astype(float).to_numpy()
+
+    cfg = _base_cfg()
+
+    def _sc(name, area):
+        return {'name': name, 'area_fraction': area,
+                'reservoirs': {'recession_coefficients': [14, 500],
+                               'exfiltration_fractions': [0.3, 1.0],
+                               'maximum_effective_depths__mm': [20.0, float('inf')]},
+                'initial_conditions': {
+                    'water_reservoir_effective_depths__mm': [5, 300]}}
+    cfg['sub_catchments'] = [_sc('a', 0.2), _sc('b', 0.3), _sc('c', 0.5)]
+    b3 = _run(_write(tmp_path, cfg, "three.yml"))
+    assert b3.n_sub_catchments == 3
+    assert len(b3.reservoirs) == 6
+    q_three = b3.hydrodata[Q_COL].astype(float).to_numpy()
+
+    np.testing.assert_allclose(q_three, q_one, rtol=1e-9, atol=1e-9, equal_nan=True)
+
+
+def test_jit_matches_pure_python_three_sub_catchments(tmp_path, monkeypatch):
+    """JIT and pure-Python agree for three sub-catchments with cascades of
+    different lengths (1, 2, 3) and the advanced mechanics enabled — exercising
+    the flat reservoir-index ranges across three zones in both loops."""
+    pytest.importorskip("numba", exc_type=ImportError)
+    import mnished
+    import mnished.mnished as _m
+
+    cfg = _base_cfg()
+    cfg['general']['et_alpha'] = 0.6
+    cfg['modules']['et_reservoir_draw'] = True
+    cfg['sub_catchments'] = [
+        {'name': 'one', 'area_fraction': 0.5,
+         'reservoirs': {
+             'recession_coefficients': [200],
+             'exfiltration_fractions': [1.0],
+             'maximum_effective_depths__mm': [float('inf')],
+             'multipath_thresholds__mm': [20.0],
+             'multipath_timescales__days': [3.0]},
+         'initial_conditions': {
+             'water_reservoir_effective_depths__mm': [80],
+             'snowpack__mm_SWE': 2.0}},
+        {'name': 'two', 'area_fraction': 0.3,
+         'reservoirs': {
+             'recession_coefficients': [14, 500],
+             'exfiltration_fractions': [0.3, 1.0],
+             'maximum_effective_depths__mm': [20.0, float('inf')],
+             'recession_exponents': [2.0, 1.0],
+             'junction_types': ['threshold', 'fraction'],
+             'H_threshold__mm': [3.0, 0.0],
+             'tile_fractions': [0.3, 0.0],
+             'tile_residence_times__days': [3.0, None]},
+         'initial_conditions': {
+             'water_reservoir_effective_depths__mm': [5, 300],
+             'snowpack__mm_SWE': 1.0}},
+        {'name': 'three', 'area_fraction': 0.2,
+         'reservoirs': {
+             'recession_coefficients': [10, 100, 2000],
+             'exfiltration_fractions': [0.4, 0.7, 1.0],
+             'maximum_effective_depths__mm': [float('inf'), float('inf'),
+                                              float('inf')],
+             'junction_types': ['leakance', 'fraction', 'fraction'],
+             'leakance_R__days': [50.0, None, None]},
+         'initial_conditions': {
+             'water_reservoir_effective_depths__mm': [8, 60, 500],
+             'snowpack__mm_SWE': 0.5}},
+    ]
+    cfg_path = _write(tmp_path, cfg, "advanced_3sc.yml")
+
+    b_jit = mnished.Buckets()
+    b_jit.initialize(cfg_path)
+    b_jit.run()
+    q_jit = b_jit.hydrodata[Q_COL].astype(float).to_numpy()
+    s_jit = b_jit.hydrodata[S_COL].astype(float).to_numpy()
+
+    monkeypatch.setattr(_m, "_numba_available", False)
+    b_py = mnished.Buckets()
+    b_py.initialize(cfg_path)
+    b_py.run()
+    q_py = b_py.hydrodata[Q_COL].astype(float).to_numpy()
+    s_py = b_py.hydrodata[S_COL].astype(float).to_numpy()
+
+    assert len(b_jit.reservoirs) == 6        # 1 + 2 + 3 across three zones
+    np.testing.assert_allclose(q_jit, q_py, rtol=1e-7, atol=1e-9, equal_nan=True)
+    np.testing.assert_allclose(s_jit, s_py, rtol=1e-7, atol=1e-9, equal_nan=True)


### PR DESCRIPTION
## Summary

Adds **parallel sub-catchments**: a basin can be partitioned into spatially
distinct hydraulic zones that drain to the same channel *in parallel*, each its
own reservoir cascade with its own snowpack and frozen-ground state. Basin
discharge and storage are the area-weighted means over sub-catchments. A single
sub-catchment of `area_fraction: 1.0` reproduces the previous single-cascade
model exactly, so existing configs and calls are unchanged.

## Motivation

The existing cascade is *vertical* (each reservoir recharges the one beneath).
Some basins — e.g. Wild Rice River (MN), with till uplands and lake-clay
lowlands draining to one channel — have genuinely parallel zones that a single
vertical cascade can only partially represent.

## What's included

- `SubCatchment` class; `Buckets.sub_catchments` / `n_sub_catchments`;
  `reservoirs` becomes a flattened property (back-compat setter retained).
- `sub_catchments:` YAML parsing + validation (areas sum to 1, unique names,
  ≥1 reservoir; per-sub-catchment `initial_conditions`).
- Parallel, area-weighted routing in **both** time loops — pure-Python
  `update()` and the Numba `_jit_run` (flat reservoir arrays + per-zone index
  ranges).
- `run_and_score(sub_catchments=[…])` per-zone parameter override (Option B);
  per-sub-catchment state **chained across decade windows**
  (`final_states`/`initial_states` nest at K>1, stay flat at K=1).
- `store_depths` output columns labeled by sub-catchment at K>1.
- Tests (the design's cases + K=2 and K=3 JIT↔pure-Python equivalence,
  chaining continuity) and documentation spliced through the model description,
  configuration, calibration, landing, and getting-started pages.

## Backward compatibility

K=1 is bit-identical at every commit; no YAML or `run_and_score` changes are
required for existing single-cascade models. Output column names are unchanged
at K=1.

## Verification

- 161 pass / 4 skip; the sub-catchment suite passes under Numba.
- JIT == pure-Python verified for K=2 and K=3 with differing cascade lengths and
  the advanced mechanics on (multipath, junctions, tile, power-law, snow, FGI,
  reservoir-draw ET): Q/SWE to 0, storage to ~1e-13.
- A chained two-window K=2 run reproduces a single continuous run to 1e-9.
- Docs build clean under `-W`; ruff clean.

## Deferred (designed-in, not in this PR)

- **Per-sub-catchment forcing** — the YAML `forcing:` hook is parsed but raises
  `NotImplementedError`; forcing is basin-shared for now.
- **BMI K>1 aggregation** — basin SWE/FGI currently report the first
  sub-catchment; tracked in #16.

## Commits (13)

`a9d037c` SubCatchment class · `a313929` reservoirs property · `79898bc` YAML
parsing · `a2d4507` pure-Python loop · `93375d1` JIT loop · `cc89dd4`
run_and_score override · `f5c6945` tests · `07699a2` initial docs · `28b71eb`
decadal chaining · `8da29c2` K=3 tests · `4820ff6` + `6d4ecf1` docs splice ·
`0ea2f1c` store_depths naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)